### PR TITLE
AzureSettings reader and writer

### DIFF
--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	envAzureCloud              = "GF_PLUGIN_AZURE_CLOUD"
-	envManagedIdentityEnabled  = "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED"
-	envManagedIdentityClientId = "GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID"
+	envAzureCloud              = "GFAZPL_AZURE_CLOUD"
+	envManagedIdentityEnabled  = "GFAZPL_MANAGED_IDENTITY_ENABLED"
+	envManagedIdentityClientId = "GFAZPL_MANAGED_IDENTITY_CLIENT_ID"
 
 	// Pre Grafana 9.x variables
 	fallbackAzureCloud              = "AZURE_CLOUD"

--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -1,0 +1,55 @@
+package azsettings
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana-azure-sdk-go/azsettings/internal/envutil"
+)
+
+const (
+	envAzureCloud              = "GF_PLUGIN_AZURE_CLOUD"
+	envManagedIdentityEnabled  = "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED"
+	envManagedIdentityClientId = "GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID"
+
+	// Pre Grafana 9.x variables
+	fallbackAzureCloud              = "AZURE_CLOUD"
+	fallbackManagedIdentityEnabled  = "AZURE_MANAGED_IDENTITY_ENABLED"
+	fallbackManagedIdentityClientId = "AZURE_MANAGED_IDENTITY_CLIENT_ID"
+)
+
+func ReadFromEnv() (*AzureSettings, error) {
+	azureSettings := &AzureSettings{}
+
+	azureSettings.Cloud = envutil.GetOrFallback(envAzureCloud, fallbackAzureCloud, AzurePublic)
+
+	// Managed Identity
+	if msiEnabled, err := envutil.GetBoolOrFallback(envManagedIdentityEnabled, fallbackManagedIdentityEnabled, false); err != nil {
+		err = fmt.Errorf("invalid Azure configuration: %w", err)
+		return nil, err
+	} else if msiEnabled {
+		azureSettings.ManagedIdentityEnabled = true
+		azureSettings.ManagedIdentityClientId = envutil.GetOrFallback(envManagedIdentityClientId, fallbackManagedIdentityClientId, "")
+	}
+
+	return azureSettings, nil
+}
+
+func WriteToEnvStr(azureSettings *AzureSettings) []string {
+	var envs []string
+
+	if azureSettings != nil {
+		if azureSettings.Cloud != "" {
+			envs = append(envs, fmt.Sprintf("%s=%s", envAzureCloud, azureSettings.Cloud))
+		}
+
+		if azureSettings.ManagedIdentityEnabled {
+			envs = append(envs, fmt.Sprintf("%s=true", envManagedIdentityEnabled))
+
+			if azureSettings.ManagedIdentityClientId != "" {
+				envs = append(envs, fmt.Sprintf("%s=%s", envManagedIdentityClientId, azureSettings.ManagedIdentityClientId))
+			}
+		}
+	}
+
+	return envs
+}

--- a/azsettings/env_test.go
+++ b/azsettings/env_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestReadFromEnv(t *testing.T) {
 	t.Run("should set cloud if variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_AZURE_CLOUD", "TestCloud")
+		unset, err := setEnvVar("GFAZPL_AZURE_CLOUD", "TestCloud")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -20,10 +21,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set cloud if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_AZURE_CLOUD", "")
+		unset, err := setEnvVar("GFAZPL_AZURE_CLOUD", "")
 		require.NoError(t, err)
-		err = os.Setenv("AZURE_CLOUD", "FallbackCloud")
+		defer unset()
+		unset, err = setEnvVar("AZURE_CLOUD", "FallbackCloud")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -32,10 +35,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set cloud to public cloud if variable is not set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_AZURE_CLOUD", "")
+		unset, err := setEnvVar("GFAZPL_AZURE_CLOUD", "")
 		require.NoError(t, err)
-		err = os.Setenv("AZURE_CLOUD", "")
+		defer unset()
+		unset, err = setEnvVar("AZURE_CLOUD", "")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -44,8 +49,9 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should enable managed identity if variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
+		unset, err := setEnvVar("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -54,10 +60,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should enable managed identity if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "")
+		unset, err := setEnvVar("GFAZPL_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
-		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		defer unset()
+		unset, err = setEnvVar("AZURE_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -66,10 +74,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should disable managed identity if variable is not set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_AZURE_MANAGED_IDENTITY_ENABLED", "")
+		unset, err := setEnvVar("GFAZPL_AZURE_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
-		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "")
+		defer unset()
+		unset, err = setEnvVar("AZURE_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -78,10 +88,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set client ID if variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
+		unset, err := setEnvVar("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
-		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		defer unset()
+		unset, err = setEnvVar("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -90,12 +102,15 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set client ID if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
+		unset, err := setEnvVar("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
-		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "")
+		defer unset()
+		unset, err = setEnvVar("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "")
 		require.NoError(t, err)
-		err = os.Setenv("AZURE_MANAGED_IDENTITY_CLIENT_ID", "FallbackClientId")
+		defer unset()
+		unset, err = setEnvVar("AZURE_MANAGED_IDENTITY_CLIENT_ID", "FallbackClientId")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -104,10 +119,12 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should not set client ID if managed identity is not enabled", func(t *testing.T) {
-		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "false")
+		unset, err := setEnvVar("GFAZPL_MANAGED_IDENTITY_ENABLED", "false")
 		require.NoError(t, err)
-		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		defer unset()
+		unset, err = setEnvVar("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
 		require.NoError(t, err)
+		defer unset()
 
 		azureSettings, err := ReadFromEnv()
 		require.NoError(t, err)
@@ -117,6 +134,12 @@ func TestReadFromEnv(t *testing.T) {
 }
 
 func TestWriteToEnvStr(t *testing.T) {
+	defer func() {
+		_ = os.Unsetenv(envAzureCloud)
+		_ = os.Unsetenv(envManagedIdentityEnabled)
+		_ = os.Unsetenv(envManagedIdentityClientId)
+	}()
+
 	t.Run("should return empty list if AzureSettings not set", func(t *testing.T) {
 		envs := WriteToEnvStr(nil)
 
@@ -167,4 +190,17 @@ func TestWriteToEnvStr(t *testing.T) {
 
 		assert.Len(t, envs, 0)
 	})
+}
+
+type unsetFunc = func()
+
+func setEnvVar(key string, value string) (unsetFunc, error) {
+	err := os.Setenv(key, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() {
+		_ = os.Unsetenv(key)
+	}, nil
 }

--- a/azsettings/env_test.go
+++ b/azsettings/env_test.go
@@ -1,0 +1,170 @@
+package azsettings
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFromEnv(t *testing.T) {
+	t.Run("should set cloud if variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "TestCloud")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, "TestCloud", azureSettings.Cloud)
+	})
+
+	t.Run("should set cloud if fallback variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "")
+		require.NoError(t, err)
+		err = os.Setenv("AZURE_CLOUD", "FallbackCloud")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, "FallbackCloud", azureSettings.Cloud)
+	})
+
+	t.Run("should set cloud to public cloud if variable is not set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "")
+		require.NoError(t, err)
+		err = os.Setenv("AZURE_CLOUD", "")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, AzurePublic, azureSettings.Cloud)
+	})
+
+	t.Run("should enable managed identity if variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.True(t, azureSettings.ManagedIdentityEnabled)
+	})
+
+	t.Run("should enable managed identity if fallback variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "")
+		require.NoError(t, err)
+		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.True(t, azureSettings.ManagedIdentityEnabled)
+	})
+
+	t.Run("should disable managed identity if variable is not set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "")
+		require.NoError(t, err)
+		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.False(t, azureSettings.ManagedIdentityEnabled)
+	})
+
+	t.Run("should set client ID if variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		require.NoError(t, err)
+		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, "TestClientId", azureSettings.ManagedIdentityClientId)
+	})
+
+	t.Run("should set client ID if fallback variable is set", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		require.NoError(t, err)
+		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "")
+		require.NoError(t, err)
+		err = os.Setenv("AZURE_MANAGED_IDENTITY_CLIENT_ID", "FallbackClientId")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, "FallbackClientId", azureSettings.ManagedIdentityClientId)
+	})
+
+	t.Run("should not set client ID if managed identity is not enabled", func(t *testing.T) {
+		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "false")
+		require.NoError(t, err)
+		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		require.NoError(t, err)
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, "", azureSettings.ManagedIdentityClientId)
+	})
+}
+
+func TestWriteToEnvStr(t *testing.T) {
+	t.Run("should return empty list if AzureSettings not set", func(t *testing.T) {
+		envs := WriteToEnvStr(nil)
+
+		assert.Len(t, envs, 0)
+	})
+
+	t.Run("should return cloud if set", func(t *testing.T) {
+		azureSettings := &AzureSettings{
+			Cloud: "AzureCloud",
+		}
+
+		envs := WriteToEnvStr(azureSettings)
+
+		require.Len(t, envs, 1)
+		assert.Equal(t, "GF_PLUGIN_AZURE_CLOUD=AzureCloud", envs[0])
+	})
+
+	t.Run("should return managed identity set if enabled", func(t *testing.T) {
+		azureSettings := &AzureSettings{
+			ManagedIdentityEnabled: true,
+		}
+
+		envs := WriteToEnvStr(azureSettings)
+
+		require.Len(t, envs, 1)
+		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED=true", envs[0])
+	})
+
+	t.Run("should return managed identity client ID if provided", func(t *testing.T) {
+		azureSettings := &AzureSettings{
+			ManagedIdentityEnabled:  true,
+			ManagedIdentityClientId: "c2e68b2e",
+		}
+
+		envs := WriteToEnvStr(azureSettings)
+
+		require.Len(t, envs, 2)
+		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED=true", envs[0])
+		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID=c2e68b2e", envs[1])
+	})
+
+	t.Run("should not return managed identity client ID if not enabled", func(t *testing.T) {
+		azureSettings := &AzureSettings{
+			ManagedIdentityClientId: "c2e68b2e",
+		}
+
+		envs := WriteToEnvStr(azureSettings)
+
+		assert.Len(t, envs, 0)
+	})
+}

--- a/azsettings/env_test.go
+++ b/azsettings/env_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReadFromEnv(t *testing.T) {
 	t.Run("should set cloud if variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "TestCloud")
+		err := os.Setenv("GFAZPL_AZURE_CLOUD", "TestCloud")
 		require.NoError(t, err)
 
 		azureSettings, err := ReadFromEnv()
@@ -20,7 +20,7 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set cloud if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "")
+		err := os.Setenv("GFAZPL_AZURE_CLOUD", "")
 		require.NoError(t, err)
 		err = os.Setenv("AZURE_CLOUD", "FallbackCloud")
 		require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set cloud to public cloud if variable is not set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_CLOUD", "")
+		err := os.Setenv("GFAZPL_AZURE_CLOUD", "")
 		require.NoError(t, err)
 		err = os.Setenv("AZURE_CLOUD", "")
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should enable managed identity if variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
 
 		azureSettings, err := ReadFromEnv()
@@ -54,7 +54,7 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should enable managed identity if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "")
+		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
 		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should disable managed identity if variable is not set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "")
+		err := os.Setenv("GFAZPL_AZURE_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
 		err = os.Setenv("AZURE_MANAGED_IDENTITY_ENABLED", "")
 		require.NoError(t, err)
@@ -78,9 +78,9 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set client ID if variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
-		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
 		require.NoError(t, err)
 
 		azureSettings, err := ReadFromEnv()
@@ -90,9 +90,9 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should set client ID if fallback variable is set", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "true")
+		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "true")
 		require.NoError(t, err)
-		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "")
+		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "")
 		require.NoError(t, err)
 		err = os.Setenv("AZURE_MANAGED_IDENTITY_CLIENT_ID", "FallbackClientId")
 		require.NoError(t, err)
@@ -104,9 +104,9 @@ func TestReadFromEnv(t *testing.T) {
 	})
 
 	t.Run("should not set client ID if managed identity is not enabled", func(t *testing.T) {
-		err := os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED", "false")
+		err := os.Setenv("GFAZPL_MANAGED_IDENTITY_ENABLED", "false")
 		require.NoError(t, err)
-		err = os.Setenv("GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
+		err = os.Setenv("GFAZPL_MANAGED_IDENTITY_CLIENT_ID", "TestClientId")
 		require.NoError(t, err)
 
 		azureSettings, err := ReadFromEnv()
@@ -131,7 +131,7 @@ func TestWriteToEnvStr(t *testing.T) {
 		envs := WriteToEnvStr(azureSettings)
 
 		require.Len(t, envs, 1)
-		assert.Equal(t, "GF_PLUGIN_AZURE_CLOUD=AzureCloud", envs[0])
+		assert.Equal(t, "GFAZPL_AZURE_CLOUD=AzureCloud", envs[0])
 	})
 
 	t.Run("should return managed identity set if enabled", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestWriteToEnvStr(t *testing.T) {
 		envs := WriteToEnvStr(azureSettings)
 
 		require.Len(t, envs, 1)
-		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED=true", envs[0])
+		assert.Equal(t, "GFAZPL_MANAGED_IDENTITY_ENABLED=true", envs[0])
 	})
 
 	t.Run("should return managed identity client ID if provided", func(t *testing.T) {
@@ -154,8 +154,8 @@ func TestWriteToEnvStr(t *testing.T) {
 		envs := WriteToEnvStr(azureSettings)
 
 		require.Len(t, envs, 2)
-		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_ENABLED=true", envs[0])
-		assert.Equal(t, "GF_PLUGIN_AZURE_MANAGED_IDENTITY_CLIENT_ID=c2e68b2e", envs[1])
+		assert.Equal(t, "GFAZPL_MANAGED_IDENTITY_ENABLED=true", envs[0])
+		assert.Equal(t, "GFAZPL_MANAGED_IDENTITY_CLIENT_ID=c2e68b2e", envs[1])
 	})
 
 	t.Run("should not return managed identity client ID if not enabled", func(t *testing.T) {

--- a/azsettings/internal/envutil/envutil.go
+++ b/azsettings/internal/envutil/envutil.go
@@ -1,0 +1,63 @@
+package envutil
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func Get(key string) (string, error) {
+	if strValue := os.Getenv(key); strValue == "" {
+		return "", fmt.Errorf("environment variable '%s' is not set", key)
+	} else {
+		return strValue, nil
+	}
+}
+
+func GetOrDefault(key string, defaultValue string) string {
+	if strValue := os.Getenv(key); strValue == "" {
+		return defaultValue
+	} else {
+		return strValue
+	}
+}
+
+func GetBool(key string) (bool, error) {
+	if strValue := os.Getenv(key); strValue == "" {
+		return false, fmt.Errorf("environment variable '%s' is not set", key)
+	} else if value, err := strconv.ParseBool(strValue); err != nil {
+		return false, fmt.Errorf("environment variable '%s' is invalid bool value '%s'", key, strValue)
+	} else {
+		return value, nil
+	}
+}
+
+func GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
+	if strValue := os.Getenv(key); strValue == "" {
+		return defaultValue, nil
+	} else if value, err := strconv.ParseBool(strValue); err != nil {
+		return false, fmt.Errorf("environment variable '%s' is invalid bool value '%s'", key, strValue)
+	} else {
+		return value, nil
+	}
+}
+
+// GetOrFallback to be removed with release of Grafana 9.x
+func GetOrFallback(key string, fallbackKey string, defaultValue string) string {
+	if strValue := os.Getenv(key); strValue == "" {
+		return GetOrDefault(fallbackKey, defaultValue)
+	} else {
+		return strValue
+	}
+}
+
+// GetBoolOrFallback to be removed with release of Grafana 9.x
+func GetBoolOrFallback(key string, fallbackKey string, defaultValue bool) (bool, error) {
+	if strValue := os.Getenv(key); strValue == "" {
+		return GetBoolOrDefault(fallbackKey, defaultValue)
+	} else if value, err := strconv.ParseBool(strValue); err != nil {
+		return false, fmt.Errorf("environment variable '%s' is invalid bool value '%s'", key, strValue)
+	} else {
+		return value, nil
+	}
+}

--- a/azsettings/internal/envutil/envutil_test.go
+++ b/azsettings/internal/envutil/envutil_test.go
@@ -1,0 +1,212 @@
+package envutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	envTestKey      = "ENV_VAR_TEST"
+	fallbackTestKey = "FALLBACK_VAR_TEST"
+)
+
+func TestGet(t *testing.T) {
+	t.Run("should return variable value if variable is set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+
+		value, err := Get(envTestKey)
+		require.NoError(t, err)
+		assert.Equal(t, "StringValue", value)
+	})
+
+	t.Run("should return error if variable not set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+
+		_, err = Get(envTestKey)
+		assert.Error(t, err)
+	})
+}
+
+func TestGetOrDefault(t *testing.T) {
+	t.Run("should return variable value if variable is set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+
+		value := GetOrDefault(envTestKey, "DefaultValue")
+		assert.Equal(t, "StringValue", value)
+	})
+
+	t.Run("should return default value if variable not set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+
+		value := GetOrDefault(envTestKey, "DefaultValue")
+		assert.Equal(t, "DefaultValue", value)
+	})
+}
+
+func TestGetBool(t *testing.T) {
+	t.Run("should return variable value if variable is set to a bool value", func(t *testing.T) {
+		tests := []struct {
+			EnvValue string
+			Expected bool
+		}{
+			{EnvValue: "false", Expected: false},
+			{EnvValue: "true", Expected: true},
+			{EnvValue: "FALSE", Expected: false},
+			{EnvValue: "TRUE", Expected: true},
+			{EnvValue: "False", Expected: false},
+			{EnvValue: "True", Expected: true},
+			{EnvValue: "0", Expected: false},
+			{EnvValue: "1", Expected: true},
+		}
+
+		for _, tt := range tests {
+			err := os.Setenv(envTestKey, tt.EnvValue)
+			require.NoError(t, err)
+
+			value, err := GetBool(envTestKey)
+			require.NoError(t, err)
+			assert.Equal(t, tt.Expected, value)
+			if err != nil {
+				return
+			}
+		}
+	})
+
+	t.Run("should return error if variable not set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+
+		_, err = GetBool(envTestKey)
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if variable is not bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+
+		_, err = GetBool(envTestKey)
+		assert.Error(t, err)
+	})
+}
+
+func TestGetBoolOrDefault(t *testing.T) {
+	t.Run("should return variable value if variable is set to a bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "false")
+		require.NoError(t, err)
+
+		value, err := GetBoolOrDefault(envTestKey, true)
+		require.NoError(t, err)
+		assert.Equal(t, false, value)
+	})
+
+	t.Run("should return default value if variable not set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+
+		value, err := GetBoolOrDefault(envTestKey, true)
+		require.NoError(t, err)
+		assert.Equal(t, true, value)
+	})
+
+	t.Run("should return error if variable is not bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+
+		_, err = GetBoolOrDefault(envTestKey, true)
+		assert.Error(t, err)
+	})
+}
+
+func TestGetOrFallback(t *testing.T) {
+	t.Run("should return main value if main variable is set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		require.NoError(t, err)
+
+		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
+		assert.Equal(t, "StringValue", value)
+	})
+
+	t.Run("should return fallback value if main variable is not set but fallback variable is set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		require.NoError(t, err)
+
+		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
+		assert.Equal(t, "FallbackStringValue", value)
+	})
+
+	t.Run("should return default value if neither main nor fallback variables are set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "")
+		require.NoError(t, err)
+
+		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
+		assert.Equal(t, "DefaultValue", value)
+	})
+}
+
+func TestGetBoolOrFallback(t *testing.T) {
+	t.Run("should return main value if main variable is set to a bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "true")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "false")
+		require.NoError(t, err)
+
+		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
+		require.NoError(t, err)
+		assert.Equal(t, true, value)
+	})
+
+	t.Run("should return fallback value if main variable is not set but fallback variable is set to a bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "false")
+		require.NoError(t, err)
+
+		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
+		require.NoError(t, err)
+		assert.Equal(t, false, value)
+	})
+
+	t.Run("should return default value if neither main nor fallback variables are set", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "")
+		require.NoError(t, err)
+
+		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
+		require.NoError(t, err)
+		assert.Equal(t, true, value)
+	})
+
+	t.Run("should return error if main variable is not bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "StringValue")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "false")
+		require.NoError(t, err)
+
+		_, err = GetBoolOrFallback(envTestKey, fallbackTestKey, true)
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if fallback variable is not bool value", func(t *testing.T) {
+		err := os.Setenv(envTestKey, "")
+		require.NoError(t, err)
+		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		require.NoError(t, err)
+
+		_, err = GetBoolOrFallback(envTestKey, fallbackTestKey, true)
+		assert.Error(t, err)
+	})
+}

--- a/azsettings/internal/envutil/envutil_test.go
+++ b/azsettings/internal/envutil/envutil_test.go
@@ -15,8 +15,9 @@ const (
 
 func TestGet(t *testing.T) {
 	t.Run("should return variable value if variable is set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := Get(envTestKey)
 		require.NoError(t, err)
@@ -24,8 +25,9 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("should return error if variable not set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = Get(envTestKey)
 		assert.Error(t, err)
@@ -34,16 +36,18 @@ func TestGet(t *testing.T) {
 
 func TestGetOrDefault(t *testing.T) {
 	t.Run("should return variable value if variable is set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		value := GetOrDefault(envTestKey, "DefaultValue")
 		assert.Equal(t, "StringValue", value)
 	})
 
 	t.Run("should return default value if variable not set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		value := GetOrDefault(envTestKey, "DefaultValue")
 		assert.Equal(t, "DefaultValue", value)
@@ -67,8 +71,9 @@ func TestGetBool(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			err := os.Setenv(envTestKey, tt.EnvValue)
+			unset, err := setEnvVar(envTestKey, tt.EnvValue)
 			require.NoError(t, err)
+			defer unset()
 
 			value, err := GetBool(envTestKey)
 			require.NoError(t, err)
@@ -80,16 +85,18 @@ func TestGetBool(t *testing.T) {
 	})
 
 	t.Run("should return error if variable not set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = GetBool(envTestKey)
 		assert.Error(t, err)
 	})
 
 	t.Run("should return error if variable is not bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = GetBool(envTestKey)
 		assert.Error(t, err)
@@ -98,8 +105,9 @@ func TestGetBool(t *testing.T) {
 
 func TestGetBoolOrDefault(t *testing.T) {
 	t.Run("should return variable value if variable is set to a bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "false")
+		unset, err := setEnvVar(envTestKey, "false")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := GetBoolOrDefault(envTestKey, true)
 		require.NoError(t, err)
@@ -107,8 +115,9 @@ func TestGetBoolOrDefault(t *testing.T) {
 	})
 
 	t.Run("should return default value if variable not set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := GetBoolOrDefault(envTestKey, true)
 		require.NoError(t, err)
@@ -116,8 +125,9 @@ func TestGetBoolOrDefault(t *testing.T) {
 	})
 
 	t.Run("should return error if variable is not bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = GetBoolOrDefault(envTestKey, true)
 		assert.Error(t, err)
@@ -126,30 +136,36 @@ func TestGetBoolOrDefault(t *testing.T) {
 
 func TestGetOrFallback(t *testing.T) {
 	t.Run("should return main value if main variable is set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "FallbackStringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
 		assert.Equal(t, "StringValue", value)
 	})
 
 	t.Run("should return fallback value if main variable is not set but fallback variable is set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "FallbackStringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
 		assert.Equal(t, "FallbackStringValue", value)
 	})
 
 	t.Run("should return default value if neither main nor fallback variables are set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		value := GetOrFallback(envTestKey, fallbackTestKey, "DefaultValue")
 		assert.Equal(t, "DefaultValue", value)
@@ -158,10 +174,12 @@ func TestGetOrFallback(t *testing.T) {
 
 func TestGetBoolOrFallback(t *testing.T) {
 	t.Run("should return main value if main variable is set to a bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "true")
+		unset, err := setEnvVar(envTestKey, "true")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "false")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "false")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
 		require.NoError(t, err)
@@ -169,10 +187,12 @@ func TestGetBoolOrFallback(t *testing.T) {
 	})
 
 	t.Run("should return fallback value if main variable is not set but fallback variable is set to a bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "false")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "false")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
 		require.NoError(t, err)
@@ -180,10 +200,12 @@ func TestGetBoolOrFallback(t *testing.T) {
 	})
 
 	t.Run("should return default value if neither main nor fallback variables are set", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "")
 		require.NoError(t, err)
+		defer unset()
 
 		value, err := GetBoolOrFallback(envTestKey, fallbackTestKey, true)
 		require.NoError(t, err)
@@ -191,22 +213,39 @@ func TestGetBoolOrFallback(t *testing.T) {
 	})
 
 	t.Run("should return error if main variable is not bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "StringValue")
+		unset, err := setEnvVar(envTestKey, "StringValue")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "false")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "false")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = GetBoolOrFallback(envTestKey, fallbackTestKey, true)
 		assert.Error(t, err)
 	})
 
 	t.Run("should return error if fallback variable is not bool value", func(t *testing.T) {
-		err := os.Setenv(envTestKey, "")
+		unset, err := setEnvVar(envTestKey, "")
 		require.NoError(t, err)
-		err = os.Setenv(fallbackTestKey, "FallbackStringValue")
+		defer unset()
+		unset, err = setEnvVar(fallbackTestKey, "FallbackStringValue")
 		require.NoError(t, err)
+		defer unset()
 
 		_, err = GetBoolOrFallback(envTestKey, fallbackTestKey, true)
 		assert.Error(t, err)
 	})
+}
+
+type unsetFunc = func()
+
+func setEnvVar(key string, value string) (unsetFunc, error) {
+	err := os.Setenv(key, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() {
+		_ = os.Unsetenv(key)
+	}, nil
 }

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,8 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 h1:lhSJz9RMbJcTgxifR1hUNJnn6CNYtbgEDtQV22/9RBA=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.22.0 h1:zBJcBJwte0x6PcPK7XaWDMvK2o2ZM2f1sMaqNNavQ5g=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.22.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.10.0 h1:jq5Urf8QJK6h0wr8CMiwggo4OSMkXwpArQlkSjSpaBk=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.10.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.2 h1:mM/yraAumqMMIYev6zX0oxHqX6hreUs5wXf76W47r38=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.2/go.mod h1:+nVKciyKD2J9TyVcEQ82Bo9b+3F92PiQfHrIE/zqLqM=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI41IfPoLFiFkLtb+bmGjT0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1 h1:sLZ/Y+P/5RRtsXWylBjB5lkgixYfm0MQPiwrSX//JSo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
@@ -17,10 +11,11 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9s
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -31,8 +26,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 h1:Qj1ukM4GlMWXNdMBuXcXfz/Kw9s1qm0CLY32QxuSImI=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -47,8 +40,6 @@ golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
-golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -63,7 +54,6 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
@@ -71,7 +61,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=


### PR DESCRIPTION
This PR adds reader and writer of `azsetttings.AzureSettings` for external plugins.

Both reader and writer encapsulated into single packages so it should be easier to extend the settings structure in future and have consistent validation.

`azsettings.ReadFromEnv` will be used here (by an external plugin):
[grafana/azure-data-explorer-datasource/pkg/azuredx/datasource.go#L47](https://github.com/grafana/azure-data-explorer-datasource/blob/21d17abebce9aff943ffe430564c787ee8333d30/pkg/azuredx/datasource.go#L47)

`azsettings.WriteToEnvStr` will be used here (by the Grafana plugin manager):
[grafana/grafana/pkg/plugins/manager/loader/initializer/initializer.go#L85](https://github.com/grafana/grafana/blob/ff38f24044ec3462e014d96ebb3b0ba64f300bac/pkg/plugins/manager/loader/initializer/initializer.go#L85)

I decided to rename the underlying environment variables to make them more plugin specific and eliminate a chance of clash with machine wide variables (e.g. `AZURE_CLOUD` too generic name and could be used on a host machine). I prefixed with `GF_PLUGIN_` but open for other naming approaches.

While the existing environment variables were introduced long time ago, they never been used by any Azure plugin, so they are OK to be changed.

The old variables can be removed in future (e.g. after release of Grafana 9.x).

Fixes #4