### PR TITLE
Configuration switch for On-Behalf-Of authentication

### DIFF
--- a/azsettings/env_test.go
+++ b/azsettings/env_test.go
@@ -131,6 +131,17 @@ func TestReadFromEnv(t *testing.T) {
 
 		assert.Equal(t, "", azureSettings.ManagedIdentityClientId)
 	})
+
+	t.Run("should enable client OBO if variable is set", func(t *testing.T) {
+		unset, err := setEnvVar("GFAZPL_CLIENT_OBO_ENABLED", "true")
+		require.NoError(t, err)
+		defer unset()
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.True(t, azureSettings.ClientOnBehalfOfEnabled)
+	})
 }
 
 func TestWriteToEnvStr(t *testing.T) {

--- a/azsettings/settings.go
+++ b/azsettings/settings.go
@@ -1,7 +1,10 @@
 package azsettings
 
 type AzureSettings struct {
-	Cloud                   string
+	Cloud string
+
 	ManagedIdentityEnabled  bool
 	ManagedIdentityClientId string
+
+	ClientOnBehalfOfEnabled bool
 }


### PR DESCRIPTION
This PR adds additional configuration switch to `azsettings.AzureSettings` which can control availability of the On-Behalf-Of feature in Azure Data Explorer datasource.

#### Proposed configuration in Grafana config:

```ini
[azure]
managed_identity_enabled = true

# Enable/disable On-Behalf-Of authentication using AAD client configured in a datasource
client_obo_enabled = false
```

#### Access in frontend:
```ts
import { config } from '@grafana/runtime';
...
const clientOnBehalfOfEnabled = config.azure["clientOnBehalfOfEnabled"];
```

#### Access in backend:
```go
azureSettings, err := azsettings.ReadFromEnv()
if err != nil {
	backend.Logger.Error("failed to read Azure settings from Grafana", "error", err.Error())
	return nil, err
}
...
clientOnBehalfOfEnabled := azureSettings.ClientOnBehalfOfEnabled
```