### PR TITLE
Explicitly set client ID to nil for system assigned selection

### DIFF
--- a/aztokenprovider/token_provider.go
+++ b/aztokenprovider/token_provider.go
@@ -140,8 +140,16 @@ func (c *managedIdentityTokenRetriever) GetCacheKey() string {
 }
 
 func (c *managedIdentityTokenRetriever) Init() error {
-	options := &azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(c.clientId)}
-	if credential, err := azidentity.NewManagedIdentityCredential(options); err != nil {
+	var credential *azidentity.ManagedIdentityCredential
+	var err error
+	if c.clientId != "" {
+		options := &azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(c.clientId)}
+		credential, err = azidentity.NewManagedIdentityCredential(options)
+	} else {
+		// In order to select the system assigned identity the client ID must explicitly be set to nil
+		credential, err = azidentity.NewManagedIdentityCredential(nil)
+	}
+	if err != nil {
 		return err
 	} else {
 		c.credential = credential


### PR DESCRIPTION
Based on [this](https://github.com/Azure/azure-sdk-for-go/issues/18501#issuecomment-1180746751) comment, a change in the `azidentity` package now requires the `clientId` to be explicitly set to `nil` in order to allow for the system assigned identity to be selected.

Will fix #50397 once released.