### PR TITLE
Add cloud name for customizing specific Azure configuration

### DIFF
--- a/azsettings/clouds.go
+++ b/azsettings/clouds.go
@@ -7,6 +7,7 @@ const (
 	AzureChina        = "AzureChinaCloud"
 	AzureUSGovernment = "AzureUSGovernment"
 	AzureGermany      = "AzureGermanCloud"
+	AzureCustomized   = "AzureCustomizedCloud"
 )
 
 func NormalizeAzureCloud(cloudName string) string {
@@ -48,6 +49,16 @@ func NormalizeAzureCloud(cloudName string) string {
 		fallthrough
 	case "germany":
 		return AzureGermany
+
+	// Customized
+	case "azurecustomizedcloud":
+		fallthrough
+	case "azurecustomized":
+		fallthrough
+	case "custom":
+		fallthrough
+	case "customized":
+		return AzureCustomized
 	}
 
 	// Pass the name unchanged if it's not known

--- a/azsettings/clouds.go
+++ b/azsettings/clouds.go
@@ -52,12 +52,6 @@ func NormalizeAzureCloud(cloudName string) string {
 
 	// Customized
 	case "azurecustomizedcloud":
-		fallthrough
-	case "azurecustomized":
-		fallthrough
-	case "custom":
-		fallthrough
-	case "customized":
 		return AzureCustomized
 	}
 


### PR DESCRIPTION
Add a new entry of Azure cloud name in azsettings, which is intended to represent specific Azure cloud in Grafana whose configuration is variable and will be customized by cloud admin or automated scripts.