### PR TITLE
Remove Germany and Customized clouds

### DIFF
--- a/azsettings/clouds.go
+++ b/azsettings/clouds.go
@@ -6,8 +6,6 @@ const (
 	AzurePublic       = "AzureCloud"
 	AzureChina        = "AzureChinaCloud"
 	AzureUSGovernment = "AzureUSGovernment"
-	AzureGermany      = "AzureGermanCloud"
-	AzureCustomized   = "AzureCustomizedCloud"
 )
 
 func NormalizeAzureCloud(cloudName string) string {
@@ -39,20 +37,6 @@ func NormalizeAzureCloud(cloudName string) string {
 		fallthrough
 	case "usgovernment":
 		return AzureUSGovernment
-
-	// Germany
-	case "azuregermancloud":
-		fallthrough
-	case "azuregermany":
-		fallthrough
-	case "german":
-		fallthrough
-	case "germany":
-		return AzureGermany
-
-	// Customized
-	case "azurecustomizedcloud":
-		return AzureCustomized
 	}
 
 	// Pass the name unchanged if it's not known

--- a/azsettings/clouds_test.go
+++ b/azsettings/clouds_test.go
@@ -1,0 +1,17 @@
+package azsettings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var UserDefinedAzureCustomized = "AzureCustomizedCloud"
+
+func TestNormalizeAzureCloud(t *testing.T) {
+	t.Run("should return unknown clouds as is", func(t *testing.T) {
+		cloud := UserDefinedAzureCustomized
+		normalized := NormalizeAzureCloud(cloud)
+		assert.Equal(t, UserDefinedAzureCustomized, normalized)
+	})
+}


### PR DESCRIPTION
Germany cloud has been deprecated some time ago.

Dedicated definition for "Customized" cloud also not needed because Azure SDK doesn't enforce constraints on passed names of clouds.