### PR TITLE
User-based authentication credentials

### DIFF
--- a/azcredentials/builder.go
+++ b/azcredentials/builder.go
@@ -2,10 +2,12 @@ package azcredentials
 
 import (
 	"fmt"
+
+	"github.com/grafana/grafana-azure-sdk-go/azcredentials/internal/maputil"
 )
 
 func FromDatasourceData(data map[string]interface{}, secureData map[string]string) (AzureCredentials, error) {
-	if credentialsObj, err := getMapOptional(data, "azureCredentials"); err != nil {
+	if credentialsObj, err := maputil.GetMapOptional(data, "azureCredentials"); err != nil {
 		return nil, err
 	} else if credentialsObj == nil {
 		return nil, nil
@@ -15,26 +17,30 @@ func FromDatasourceData(data map[string]interface{}, secureData map[string]strin
 }
 
 func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData map[string]string) (AzureCredentials, error) {
-	authType, err := getStringValue(credentialsObj, "authType")
+	authType, err := maputil.GetString(credentialsObj, "authType")
 	if err != nil {
 		return nil, err
 	}
 
 	switch authType {
+	case AzureAuthCurrentUserIdentity:
+		credentials := &AadCurrentUserCredentials{}
+		return credentials, nil
+
 	case AzureAuthManagedIdentity:
 		credentials := &AzureManagedIdentityCredentials{}
 		return credentials, nil
 
 	case AzureAuthClientSecret:
-		cloud, err := getStringValue(credentialsObj, "azureCloud")
+		cloud, err := maputil.GetString(credentialsObj, "azureCloud")
 		if err != nil {
 			return nil, err
 		}
-		tenantId, err := getStringValue(credentialsObj, "tenantId")
+		tenantId, err := maputil.GetString(credentialsObj, "tenantId")
 		if err != nil {
 			return nil, err
 		}
-		clientId, err := getStringValue(credentialsObj, "clientId")
+		clientId, err := maputil.GetString(credentialsObj, "clientId")
 		if err != nil {
 			return nil, err
 		}
@@ -48,36 +54,33 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 		}
 		return credentials, nil
 
+	case AzureAuthClientSecretObo:
+		cloud, err := maputil.GetString(credentialsObj, "azureCloud")
+		if err != nil {
+			return nil, err
+		}
+		tenantId, err := maputil.GetString(credentialsObj, "tenantId")
+		if err != nil {
+			return nil, err
+		}
+		clientId, err := maputil.GetString(credentialsObj, "clientId")
+		if err != nil {
+			return nil, err
+		}
+		clientSecret := secureData["azureClientSecret"]
+
+		credentials := &AzureClientSecretOboCredentials{
+			ClientSecretCredentials: AzureClientSecretCredentials{
+				AzureCloud:   cloud,
+				TenantId:     tenantId,
+				ClientId:     clientId,
+				ClientSecret: clientSecret,
+			},
+		}
+		return credentials, nil
+
 	default:
 		err := fmt.Errorf("the authentication type '%s' not supported", authType)
 		return nil, err
-	}
-}
-
-func getMapOptional(obj map[string]interface{}, key string) (map[string]interface{}, error) {
-	if untypedValue, ok := obj[key]; ok {
-		if value, ok := untypedValue.(map[string]interface{}); ok {
-			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be an object", key)
-			return nil, err
-		}
-	} else {
-		// Value optional, not error
-		return nil, nil
-	}
-}
-
-func getStringValue(obj map[string]interface{}, key string) (string, error) {
-	if untypedValue, ok := obj[key]; ok {
-		if value, ok := untypedValue.(string); ok {
-			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be a string", key)
-			return "", err
-		}
-	} else {
-		err := fmt.Errorf("the field '%s' should be set", key)
-		return "", err
 	}
 }

--- a/azcredentials/builder_test.go
+++ b/azcredentials/builder_test.go
@@ -1,0 +1,125 @@
+package azcredentials
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromDatasourceData(t *testing.T) {
+	t.Run("should return nil when no credentials configured", func(t *testing.T) {
+		var data = map[string]interface{}{}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return current user credentials when current user auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType": "currentuser",
+			},
+		}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AadCurrentUserCredentials{}, result)
+	})
+
+	t.Run("should return managed identity credentials when managed identity auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType": "msi",
+			},
+		}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureManagedIdentityCredentials{}, result)
+		credential := (result).(*AzureManagedIdentityCredentials)
+
+		// ClientId currently not parsed
+		assert.Equal(t, credential.ClientId, "")
+	})
+
+	t.Run("should return client secret credentials when client secret auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "clientsecret",
+				"azureCloud": "AzureChinaCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"azureClientSecret": "FAKE-SECRET",
+		}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureClientSecretCredentials{}, result)
+		credential := (result).(*AzureClientSecretCredentials)
+
+		assert.Equal(t, credential.AzureCloud, azsettings.AzureChina)
+		assert.Equal(t, credential.TenantId, "TENANT-ID")
+		assert.Equal(t, credential.ClientId, "CLIENT-TD")
+		assert.Equal(t, credential.ClientSecret, "FAKE-SECRET")
+	})
+
+	t.Run("should return on-behalf-of credentials when on-behalf-of auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "clientsecret-obo",
+				"azureCloud": "AzureChinaCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"azureClientSecret": "FAKE-SECRET",
+		}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureClientSecretOboCredentials{}, result)
+		credential := (result).(*AzureClientSecretOboCredentials)
+
+		require.NotNil(t, credential.ClientSecretCredentials)
+		assert.Equal(t, credential.ClientSecretCredentials.AzureCloud, azsettings.AzureChina)
+		assert.Equal(t, credential.ClientSecretCredentials.TenantId, "TENANT-ID")
+		assert.Equal(t, credential.ClientSecretCredentials.ClientId, "CLIENT-TD")
+		assert.Equal(t, credential.ClientSecretCredentials.ClientSecret, "FAKE-SECRET")
+	})
+
+	t.Run("should return error when credentials not supported", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "invalid",
+				"azureCloud": "AzureChinaCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"azureClientSecret": "FAKE-SECRET",
+		}
+
+		_, err := FromDatasourceData(data, secureData)
+		assert.Error(t, err)
+	})
+}

--- a/azcredentials/credentials.go
+++ b/azcredentials/credentials.go
@@ -1,12 +1,17 @@
 package azcredentials
 
 const (
-	AzureAuthManagedIdentity = "msi"
-	AzureAuthClientSecret    = "clientsecret"
+	AzureAuthCurrentUserIdentity = "currentuser"
+	AzureAuthManagedIdentity     = "msi"
+	AzureAuthClientSecret        = "clientsecret"
+	AzureAuthClientSecretObo     = "clientsecret-obo"
 )
 
 type AzureCredentials interface {
 	AzureAuthType() string
+}
+
+type AadCurrentUserCredentials struct {
 }
 
 type AzureManagedIdentityCredentials struct {
@@ -21,10 +26,22 @@ type AzureClientSecretCredentials struct {
 	ClientSecret string
 }
 
+type AzureClientSecretOboCredentials struct {
+	ClientSecretCredentials AzureClientSecretCredentials
+}
+
+func (credentials *AadCurrentUserCredentials) AzureAuthType() string {
+	return AzureAuthCurrentUserIdentity
+}
+
 func (credentials *AzureManagedIdentityCredentials) AzureAuthType() string {
 	return AzureAuthManagedIdentity
 }
 
 func (credentials *AzureClientSecretCredentials) AzureAuthType() string {
 	return AzureAuthClientSecret
+}
+
+func (credentials *AzureClientSecretOboCredentials) AzureAuthType() string {
+	return AzureAuthClientSecretObo
 }

--- a/azcredentials/credentials.go
+++ b/azcredentials/credentials.go
@@ -11,13 +11,17 @@ type AzureCredentials interface {
 	AzureAuthType() string
 }
 
+// AadCurrentUserCredentials "Current User" user identity credentials of the current Grafana user.
 type AadCurrentUserCredentials struct {
 }
 
+// AzureManagedIdentityCredentials "Managed Identity" service managed identity credentials configured
+// for the current Grafana instance.
 type AzureManagedIdentityCredentials struct {
 	ClientId string
 }
 
+// AzureClientSecretCredentials "App Registration" AAD service identity credentials configured in the datasource.
 type AzureClientSecretCredentials struct {
 	AzureCloud   string
 	Authority    string
@@ -26,6 +30,8 @@ type AzureClientSecretCredentials struct {
 	ClientSecret string
 }
 
+// AzureClientSecretOboCredentials "App Registration (On-Behalf-Of)" user identity credentials obtained using
+// service identity configured in the datasource.
 type AzureClientSecretOboCredentials struct {
 	ClientSecretCredentials AzureClientSecretCredentials
 }

--- a/azcredentials/internal/maputil/maputil.go
+++ b/azcredentials/internal/maputil/maputil.go
@@ -1,0 +1,87 @@
+package maputil
+
+import "fmt"
+
+func GetMap(obj map[string]interface{}, key string) (map[string]interface{}, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(map[string]interface{}); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be an object", key)
+			return nil, err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return nil, err
+	}
+}
+
+func GetMapOptional(obj map[string]interface{}, key string) (map[string]interface{}, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(map[string]interface{}); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be an object", key)
+			return nil, err
+		}
+	} else {
+		// Value optional, not error
+		return nil, nil
+	}
+}
+
+func GetBool(obj map[string]interface{}, key string) (bool, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(bool); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a bool", key)
+			return false, err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return false, err
+	}
+}
+
+func GetBoolOptional(obj map[string]interface{}, key string) (bool, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(bool); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a bool", key)
+			return false, err
+		}
+	} else {
+		// Value optional, not error
+		return false, nil
+	}
+}
+
+func GetString(obj map[string]interface{}, key string) (string, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(string); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a string", key)
+			return "", err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return "", err
+	}
+}
+
+func GetStringOptional(obj map[string]interface{}, key string) (string, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(string); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a string", key)
+			return "", err
+		}
+	} else {
+		// Value optional, not error
+		return "", nil
+	}
+}

--- a/azcredentials/internal/maputil/maputil_test.go
+++ b/azcredentials/internal/maputil/maputil_test.go
@@ -1,0 +1,137 @@
+package maputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var data = map[string]interface{}{
+	"number_field":  42,
+	"boolean_field": true,
+	"string_field":  "string_value",
+	"object_field":  map[string]interface{}{},
+}
+
+func TestGetMap(t *testing.T) {
+	t.Run("should return error if given field not found", func(t *testing.T) {
+		_, err := GetMap(data, "not_exist")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if value not a map", func(t *testing.T) {
+		_, err := GetMap(data, "string_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return map value of the given field", func(t *testing.T) {
+		value, err := GetMap(data, "object_field")
+		require.NoError(t, err)
+
+		assert.NotNil(t, value)
+		assert.IsType(t, map[string]interface{}{}, value)
+	})
+}
+
+func TestGetMapOptional(t *testing.T) {
+	t.Run("should return nil if given field not found", func(t *testing.T) {
+		value, err := GetMapOptional(data, "not_exist")
+		require.NoError(t, err)
+
+		assert.Nil(t, value)
+	})
+
+	t.Run("should return error if value not a map", func(t *testing.T) {
+		_, err := GetMapOptional(data, "string_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return map value of the given field", func(t *testing.T) {
+		value, err := GetMapOptional(data, "object_field")
+		require.NoError(t, err)
+
+		assert.NotNil(t, value)
+		assert.IsType(t, map[string]interface{}{}, value)
+	})
+}
+
+func TestGetBool(t *testing.T) {
+	t.Run("should return error if given field not found", func(t *testing.T) {
+		_, err := GetBool(data, "not_exist")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if value not a bool", func(t *testing.T) {
+		_, err := GetBool(data, "string_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return bool value of the given field", func(t *testing.T) {
+		value, err := GetBool(data, "boolean_field")
+		require.NoError(t, err)
+
+		assert.Equal(t, true, value)
+	})
+}
+
+func TestGetBoolOptional(t *testing.T) {
+	t.Run("should return false if given field not found", func(t *testing.T) {
+		value, err := GetBoolOptional(data, "not_exist")
+		require.NoError(t, err)
+
+		assert.Equal(t, false, value)
+	})
+
+	t.Run("should return error if value not a bool", func(t *testing.T) {
+		_, err := GetBoolOptional(data, "string_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return bool value of the given field", func(t *testing.T) {
+		value, err := GetBoolOptional(data, "boolean_field")
+		require.NoError(t, err)
+
+		assert.Equal(t, true, value)
+	})
+}
+
+func TestGetString(t *testing.T) {
+	t.Run("should return error if given field not found", func(t *testing.T) {
+		_, err := GetString(data, "not_exist")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if value not a string", func(t *testing.T) {
+		_, err := GetString(data, "number_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return string value of the given field", func(t *testing.T) {
+		value, err := GetString(data, "string_field")
+		require.NoError(t, err)
+
+		assert.Equal(t, "string_value", value)
+	})
+}
+
+func TestGetStringOptional(t *testing.T) {
+	t.Run("should return empty string if given field not found", func(t *testing.T) {
+		value, err := GetStringOptional(data, "not_exist")
+		require.NoError(t, err)
+
+		assert.Equal(t, "", value)
+	})
+
+	t.Run("should return error if value not a string", func(t *testing.T) {
+		_, err := GetStringOptional(data, "number_field")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return string value of the given field", func(t *testing.T) {
+		value, err := GetStringOptional(data, "string_field")
+		require.NoError(t, err)
+
+		assert.Equal(t, "string_value", value)
+	})
+}


### PR DESCRIPTION
Adding two new credential types:
* `azcredentials.AadCurrentUserCredentials`
* `azcredentials.AzureClientSecretOboCredentials`

These credentials assume that authentication into a datasource performed using identity of the currently signed-in AAD user, as opposed to a service identity credentials stored with the datasource.

The user identity credentials can be supported only in scenarios where Grafana configured with AAD user authentication.

### AadCurrentUserCredentials

Zero configuration "Current User" authentication. Assumes that all settings required for successful access token exchange are configured at the level of Grafana instance and there's no input required from the end user.

Similar to "access token pass-thru" but in case of pass-thru the access token is being sent to a datasource "as is", and in this case, a datasource scoped access token is being properly requested from an identity provider configured with Grafana instance.

This is credential type definition and it doesn't govern how specifically identity provider should be configured at the Grafana instance level (this is responsibility of a token provider implementation).

### AzureClientSecretOboCredentials

"App Registration (on-behalf-of)" is similar to "Current User" with only difference is that AAD identity provider and AAD app provided by the user rather than configured at the Grafana instance level.

Configuration schema is identical to "App Registration" (aka client secret) but instead of requesting access token for the configured service identity itself, the service identity used to request an access token on-behalf-of currently signed user.