### PR TITLE
Get cloud of given credentials

### DIFF
--- a/azcredentials/cloud.go
+++ b/azcredentials/cloud.go
@@ -1,0 +1,25 @@
+package azcredentials
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+)
+
+func GetAzureCloud(settings *azsettings.AzureSettings, credentials AzureCredentials) (string, error) {
+	switch c := credentials.(type) {
+	case *AadCurrentUserCredentials:
+		// In case of user identity, the cloud is always same as where Grafana is hosted
+		return settings.GetDefaultCloud(), nil
+	case *AzureManagedIdentityCredentials:
+		// In case of managed identity, the cloud is always same as where Grafana is hosted
+		return settings.GetDefaultCloud(), nil
+	case *AzureClientSecretCredentials:
+		return c.AzureCloud, nil
+	case *AzureClientSecretOboCredentials:
+		return c.ClientSecretCredentials.AzureCloud, nil
+	default:
+		err := fmt.Errorf("the Azure credentials of type '%s' not supported", c.AzureAuthType())
+		return "", err
+	}
+}

--- a/azsettings/settings.go
+++ b/azsettings/settings.go
@@ -5,3 +5,11 @@ type AzureSettings struct {
 	ManagedIdentityEnabled  bool
 	ManagedIdentityClientId string
 }
+
+func (settings *AzureSettings) GetDefaultCloud() string {
+	cloudName := settings.Cloud
+	if cloudName == "" {
+		return AzurePublic
+	}
+	return cloudName
+}


### PR DESCRIPTION
Two helper functions to get cloud information of credentials:

* `settings.GetDefaultCloud()` returns default cloud for credentials in this Grafana instance.
* `azcredentials.GetAzureCloud(settings, credentials)` returns cloud for the given credentials object.