### PR TITLE
Support legacy client secret for AzureClientSecretCredentials and OBO

### DIFF
--- a/azcredentials/builder.go
+++ b/azcredentials/builder.go
@@ -44,7 +44,11 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 		if err != nil {
 			return nil, err
 		}
-		clientSecret := secureData["azureClientSecret"]
+		clientSecret, ok := secureData["azureClientSecret"]
+		if !ok {
+			// Use legacy client secret if it was preserved during migration of credentials
+			clientSecret = secureData["clientSecret"]
+		}
 
 		credentials := &AzureClientSecretCredentials{
 			AzureCloud:   cloud,
@@ -67,7 +71,11 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 		if err != nil {
 			return nil, err
 		}
-		clientSecret := secureData["azureClientSecret"]
+		clientSecret, ok := secureData["azureClientSecret"]
+		if !ok {
+			// Use legacy client secret if it was preserved during migration of credentials
+			clientSecret = secureData["clientSecret"]
+		}
 
 		credentials := &AzureClientSecretOboCredentials{
 			ClientSecretCredentials: AzureClientSecretCredentials{

--- a/azcredentials/builder_test.go
+++ b/azcredentials/builder_test.go
@@ -106,6 +106,77 @@ func TestFromDatasourceData(t *testing.T) {
 		assert.Equal(t, credential.ClientSecretCredentials.ClientSecret, "FAKE-SECRET")
 	})
 
+	t.Run("should return client secret when legacy client secret saved", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "clientsecret",
+				"azureCloud": "AzureCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"clientSecret": "FAKE-LEGACY-SECRET",
+		}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		require.IsType(t, &AzureClientSecretCredentials{}, result)
+		credential := (result).(*AzureClientSecretCredentials)
+
+		assert.Equal(t, credential.ClientSecret, "FAKE-LEGACY-SECRET")
+	})
+
+	t.Run("should return on-behalf-of client secret when legacy client secret saved", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "clientsecret-obo",
+				"azureCloud": "AzureCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"clientSecret": "FAKE-LEGACY-SECRET",
+		}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		require.IsType(t, &AzureClientSecretOboCredentials{}, result)
+		credential := (result).(*AzureClientSecretOboCredentials)
+
+		require.NotNil(t, credential.ClientSecretCredentials)
+		assert.Equal(t, credential.ClientSecretCredentials.ClientSecret, "FAKE-LEGACY-SECRET")
+	})
+
+	t.Run("should ignore legacy client secret if new client secret saved", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":   "clientsecret",
+				"azureCloud": "AzureCloud",
+				"tenantId":   "TENANT-ID",
+				"clientId":   "CLIENT-TD",
+			},
+		}
+		var secureData = map[string]string{
+			"azureClientSecret": "FAKE-SECRET",
+			"clientSecret":      "FAKE-LEGACY-SECRET",
+		}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		require.IsType(t, &AzureClientSecretCredentials{}, result)
+		credential := (result).(*AzureClientSecretCredentials)
+
+		assert.Equal(t, credential.ClientSecret, "FAKE-SECRET")
+	})
+
 	t.Run("should return error when credentials not supported", func(t *testing.T) {
 		var data = map[string]interface{}{
 			"azureCredentials": map[string]interface{}{


### PR DESCRIPTION
During migration of credentials to the common format, existing secrets cannot be migrated because they are not accessible from the frontend.
This change allows to use the already stored legacy client secret by datasource backend even after credential was migrated.

This should allow seamless migration of credentials for Azure Data Explorer and Azure Monitor datasources.

Related:
- https://github.com/grafana/azure-data-explorer-datasource/issues/361
- https://github.com/grafana/grafana/issues/60781