### PR TITLE
User identity authentication support

### DIFF
--- a/azhttpclient/middleware.go
+++ b/azhttpclient/middleware.go
@@ -20,7 +20,7 @@ func AzureMiddleware(authOpts *AuthOptions, credentials azcredentials.AzureCrede
 		if tokenProviderFactory, ok := authOpts.customProviders[credentials.AzureAuthType()]; ok && tokenProviderFactory != nil {
 			tokenProvider, err = tokenProviderFactory(authOpts.settings, credentials)
 		} else {
-			tokenProvider, err = aztokenprovider.NewAzureAccessTokenProvider(authOpts.settings, credentials)
+			tokenProvider, err = aztokenprovider.NewAzureAccessTokenProvider(authOpts.settings, credentials, authOpts.userIdentitySupported)
 		}
 		if err != nil {
 			return errorResponse(err)

--- a/azhttpclient/options.go
+++ b/azhttpclient/options.go
@@ -10,9 +10,10 @@ import (
 type AzureTokenProviderFactory = func(*azsettings.AzureSettings, azcredentials.AzureCredentials) (aztokenprovider.AzureTokenProvider, error)
 
 type AuthOptions struct {
-	settings        *azsettings.AzureSettings
-	scopes          []string
-	customProviders map[string]AzureTokenProviderFactory
+	settings              *azsettings.AzureSettings
+	scopes                []string
+	userIdentitySupported bool
+	customProviders       map[string]AzureTokenProviderFactory
 }
 
 func NewAuthOptions(settings *azsettings.AzureSettings) *AuthOptions {
@@ -32,6 +33,10 @@ func (opts *AuthOptions) Scopes(scopes []string) {
 			}
 		}
 	}
+}
+
+func (opts *AuthOptions) AllowUserIdentity() {
+	opts.userIdentitySupported = true
 }
 
 func (opts *AuthOptions) AddTokenProvider(authType string, factory AzureTokenProviderFactory) {

--- a/aztokenprovider/retriever_clientsecret.go
+++ b/aztokenprovider/retriever_clientsecret.go
@@ -1,0 +1,86 @@
+package aztokenprovider
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+)
+
+type clientSecretTokenRetriever struct {
+	cloudConf    cloud.Configuration
+	tenantId     string
+	clientId     string
+	clientSecret string
+	credential   azcore.TokenCredential
+}
+
+func getClientSecretTokenRetriever(credentials *azcredentials.AzureClientSecretCredentials) (TokenRetriever, error) {
+	var cloudConf cloud.Configuration
+	if credentials.Authority != "" {
+		cloudConf.ActiveDirectoryAuthorityHost = credentials.Authority
+	} else {
+		var err error
+		cloudConf, err = resolveCloudConfiguration(credentials.AzureCloud)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &clientSecretTokenRetriever{
+		cloudConf:    cloudConf,
+		tenantId:     credentials.TenantId,
+		clientId:     credentials.ClientId,
+		clientSecret: credentials.ClientSecret,
+	}, nil
+}
+
+func (c *clientSecretTokenRetriever) GetCacheKey() string {
+	return fmt.Sprintf("azure|clientsecret|%s|%s|%s|%s", c.cloudConf.ActiveDirectoryAuthorityHost, c.tenantId, c.clientId, hashSecret(c.clientSecret))
+}
+
+func (c *clientSecretTokenRetriever) Init() error {
+	options := azidentity.ClientSecretCredentialOptions{}
+	options.Cloud = c.cloudConf
+	if credential, err := azidentity.NewClientSecretCredential(c.tenantId, c.clientId, c.clientSecret, &options); err != nil {
+		return err
+	} else {
+		c.credential = credential
+		return nil
+	}
+}
+
+func (c *clientSecretTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	accessToken, err := c.credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: scopes})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+func resolveCloudConfiguration(cloudName string) (cloud.Configuration, error) {
+	// Known Azure clouds
+	switch cloudName {
+	case azsettings.AzurePublic:
+		return cloud.AzurePublic, nil
+	case azsettings.AzureChina:
+		return cloud.AzureChina, nil
+	case azsettings.AzureUSGovernment:
+		return cloud.AzureGovernment, nil
+	default:
+		err := fmt.Errorf("the Azure cloud '%s' not supported", cloudName)
+		return cloud.Configuration{}, err
+	}
+}
+
+func hashSecret(secret string) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(secret))
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}

--- a/aztokenprovider/retriever_clientsecret_test.go
+++ b/aztokenprovider/retriever_clientsecret_test.go
@@ -1,0 +1,72 @@
+package aztokenprovider
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
+	defaultCredentials := func() *azcredentials.AzureClientSecretCredentials {
+		return &azcredentials.AzureClientSecretCredentials{
+			AzureCloud:   azsettings.AzurePublic,
+			Authority:    "",
+			TenantId:     "7dcf1d1a-4ec0-41f2-ac29-c1538a698bc4",
+			ClientId:     "1af7c188-e5b6-4f96-81b8-911761bdd459",
+			ClientSecret: "0416d95e-8af8-472c-aaa3-15c93c46080a",
+		}
+	}
+
+	t.Run("should return clientSecretTokenRetriever with values", func(t *testing.T) {
+		credentials := defaultCredentials()
+
+		result, err := getClientSecretTokenRetriever(credentials)
+		require.NoError(t, err)
+
+		assert.IsType(t, &clientSecretTokenRetriever{}, result)
+		credential := (result).(*clientSecretTokenRetriever)
+
+		assert.Equal(t, "https://login.microsoftonline.com/", credential.cloudConf.ActiveDirectoryAuthorityHost)
+		assert.Equal(t, "7dcf1d1a-4ec0-41f2-ac29-c1538a698bc4", credential.tenantId)
+		assert.Equal(t, "1af7c188-e5b6-4f96-81b8-911761bdd459", credential.clientId)
+		assert.Equal(t, "0416d95e-8af8-472c-aaa3-15c93c46080a", credential.clientSecret)
+	})
+
+	t.Run("authority should selected based on cloud", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.AzureCloud = azsettings.AzureChina
+
+		result, err := getClientSecretTokenRetriever(credentials)
+		require.NoError(t, err)
+
+		assert.IsType(t, &clientSecretTokenRetriever{}, result)
+		credential := (result).(*clientSecretTokenRetriever)
+
+		assert.Equal(t, "https://login.chinacloudapi.cn/", credential.cloudConf.ActiveDirectoryAuthorityHost)
+	})
+
+	t.Run("explicitly set authority should have priority over cloud", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.AzureCloud = azsettings.AzureChina
+		credentials.Authority = "https://another.com/"
+
+		result, err := getClientSecretTokenRetriever(credentials)
+		require.NoError(t, err)
+
+		assert.IsType(t, &clientSecretTokenRetriever{}, result)
+		credential := (result).(*clientSecretTokenRetriever)
+
+		assert.Equal(t, "https://another.com/", credential.cloudConf.ActiveDirectoryAuthorityHost)
+	})
+
+	t.Run("should fail with error if cloud is not supported", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.AzureCloud = "InvalidCloud"
+
+		_, err := getClientSecretTokenRetriever(credentials)
+		require.Error(t, err)
+	})
+}

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -1,0 +1,30 @@
+package aztokenprovider
+
+import (
+	"context"
+	"fmt"
+)
+
+type onBehalfOfTokenRetriever struct {
+	client  TokenClient
+	userId  string
+	idToken string
+}
+
+func (r *onBehalfOfTokenRetriever) GetCacheKey() string {
+	return fmt.Sprintf("currentuser|idtoken|%s", r.userId)
+}
+
+func (r *onBehalfOfTokenRetriever) Init() error {
+	// Nothing to initialize
+	return nil
+}
+
+func (r *onBehalfOfTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	accessToken, err := r.client.OnBehalfOf(ctx, r.idToken, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}

--- a/aztokenprovider/retriever_username.go
+++ b/aztokenprovider/retriever_username.go
@@ -1,0 +1,29 @@
+package aztokenprovider
+
+import (
+	"context"
+	"fmt"
+)
+
+type usernameTokenRetriever struct {
+	client   TokenClient
+	username string
+}
+
+func (r *usernameTokenRetriever) GetCacheKey() string {
+	return fmt.Sprintf("currentuser|username|%s", r.username)
+}
+
+func (r *usernameTokenRetriever) Init() error {
+	// Nothing to initialize
+	return nil
+}
+
+func (r *usernameTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	accessToken, err := r.client.FromUsername(ctx, r.username, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}

--- a/aztokenprovider/token_client.go
+++ b/aztokenprovider/token_client.go
@@ -1,0 +1,223 @@
+package aztokenprovider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type TokenClient interface {
+	FromClientSecret(ctx context.Context, scopes []string) (*AccessToken, error)
+	FromRefreshToken(ctx context.Context, refreshToken string, scopes []string) (*AccessToken, error)
+	OnBehalfOf(ctx context.Context, idToken string, scopes []string) (*AccessToken, error)
+	FromUsername(ctx context.Context, username string, scopes []string) (*AccessToken, error)
+}
+
+type tokenClientImpl struct {
+	httpClient   *http.Client
+	endpointUrl  string
+	clientId     string
+	clientSecret string
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	ExtExpiresIn int64  `json:"ext_expires_in"`
+	Scope        string `json:"scope"`
+}
+
+func NewTokenClient(endpointUrl string, clientId string, clientSecret string, httpClient *http.Client) (TokenClient, error) {
+	return &tokenClientImpl{
+		httpClient:   httpClient,
+		endpointUrl:  endpointUrl,
+		clientId:     clientId,
+		clientSecret: clientSecret,
+	}, nil
+}
+
+func (c *tokenClientImpl) FromClientSecret(ctx context.Context, scopes []string) (*AccessToken, error) {
+	queryParams := url.Values{}
+	queryParams.Set("grant_type", "client_credentials")
+
+	accessToken, err := c.requestToken(ctx, queryParams, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}
+
+func (c *tokenClientImpl) FromRefreshToken(ctx context.Context, refreshToken string, scopes []string) (*AccessToken, error) {
+	queryParams := url.Values{}
+	queryParams.Set("grant_type", "refresh_token")
+	queryParams.Set("refresh_token", refreshToken)
+
+	accessToken, err := c.requestToken(ctx, queryParams, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}
+
+func (c *tokenClientImpl) OnBehalfOf(ctx context.Context, idToken string, scopes []string) (*AccessToken, error) {
+	queryParams := url.Values{}
+	queryParams.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	queryParams.Set("assertion", idToken)
+	queryParams.Set("requested_token_use", "on_behalf_of")
+
+	accessToken, err := c.requestToken(ctx, queryParams, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}
+
+func (c *tokenClientImpl) FromUsername(ctx context.Context, username string, scopes []string) (*AccessToken, error) {
+	queryParams := url.Values{}
+	queryParams.Set("grant_type", "username")
+	queryParams.Set("username", username)
+
+	accessToken, err := c.requestToken(ctx, queryParams, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}
+
+func (c *tokenClientImpl) requestToken(ctx context.Context, queryParams url.Values, scopes []string) (*AccessToken, error) {
+	queryParams.Set("client_id", c.clientId)
+	queryParams.Set("client_secret", c.clientSecret)
+	addScopeQueryParam(queryParams, scopes)
+
+	result := &tokenResponse{}
+	err := requestUrlForm(ctx, c.httpClient, c.endpointUrl, queryParams, result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token: %w", err)
+	}
+
+	accessToken, err := parseAccessToken(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token: %w", err)
+	}
+
+	return accessToken, nil
+}
+
+func addScopeQueryParam(queryParams url.Values, scopes []string) {
+	scopesSanitized := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		s := strings.TrimSpace(scope)
+		if s == "" {
+			continue
+		}
+		scopesSanitized = append(scopesSanitized, scope)
+	}
+	queryParams.Set("scope", strings.Join(scopesSanitized, " "))
+}
+
+func parseAccessToken(result *tokenResponse) (*AccessToken, error) {
+	if result.AccessToken == "" {
+		return nil, errors.New("token response doesn't contain 'access_token' field")
+	}
+
+	var expiresOn = time.Time{}
+	if result.ExpiresIn > 0 {
+		expiresOn = time.Now().UTC().Add(time.Duration(result.ExpiresIn) * time.Second)
+	}
+
+	return &AccessToken{
+		Token:     result.AccessToken,
+		ExpiresOn: expiresOn,
+	}, nil
+}
+
+func requestUrlForm(ctx context.Context, httpClient *http.Client, requestUrl string, queryParams url.Values, result interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestUrl, strings.NewReader(queryParams.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	req.Header.Set("Accept", "application/json")
+
+	req.Header.Set("X-Client-SKU", "github.com/grafana/grafana-azure-sdk-go")
+	req.Header.Set("X-Client-Ver", "2.0")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func(body io.ReadCloser) {
+		err := body.Close()
+		if err != nil {
+			backend.Logger.Debug("failed to close response: %w", err)
+		}
+	}(resp.Body)
+
+	contentType, _, err := getContentType(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var bodyString string
+
+		if contentType == "application/json" {
+			bodyBytes, err := io.ReadAll(resp.Body)
+			if err == nil {
+				// TODO: Parse error details from the response body
+				bodyString = string(bodyBytes)
+			}
+		}
+
+		var errorMessage strings.Builder
+		_, _ = fmt.Fprintf(&errorMessage, "request failed with status %s", resp.Status)
+
+		if bodyString != "" {
+			_, _ = fmt.Fprintf(&errorMessage, ", body %s", bodyString)
+		}
+
+		return errors.New(errorMessage.String())
+	}
+
+	if contentType != "application/json" {
+		return fmt.Errorf("invalid response content-type '%s'", contentType)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("unable to read response: %w", err)
+	}
+
+	return nil
+}
+
+func getContentType(resp *http.Response) (string, string, error) {
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		return "", "", nil
+	}
+
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid response content-type: %w", err)
+	}
+
+	charset := params["charset"]
+
+	return mediaType, charset, nil
+}

--- a/aztokenprovider/token_provider.go
+++ b/aztokenprovider/token_provider.go
@@ -2,10 +2,13 @@ package aztokenprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/grafana/grafana-azure-sdk-go/azusercontext"
 )
 
 var (
@@ -28,32 +31,46 @@ func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials
 		return nil, err
 	}
 
-	var tokenRetriever TokenRetriever
-
 	switch c := credentials.(type) {
 	case *azcredentials.AzureManagedIdentityCredentials:
 		if !settings.ManagedIdentityEnabled {
 			err = fmt.Errorf("managed identity authentication is not enabled in Grafana config")
 			return nil, err
-		} else {
-			tokenRetriever = getManagedIdentityTokenRetriever(settings, c)
 		}
+		tokenRetriever := getManagedIdentityTokenRetriever(settings, c)
+		return &serviceTokenProvider{
+			tokenCache:     azureTokenCache,
+			tokenRetriever: tokenRetriever,
+		}, nil
 	case *azcredentials.AzureClientSecretCredentials:
-		tokenRetriever, err = getClientSecretTokenRetriever(c)
+		tokenRetriever, err := getClientSecretTokenRetriever(c)
 		if err != nil {
 			return nil, err
 		}
+		return &serviceTokenProvider{
+			tokenCache:     azureTokenCache,
+			tokenRetriever: tokenRetriever,
+		}, nil
+	case *azcredentials.AadCurrentUserCredentials:
+		if !settings.UserIdentityEnabled {
+			err = fmt.Errorf("user identity authentication is not enabled in Grafana config")
+			return nil, err
+		}
+		tokenEndpoint := settings.UserIdentityTokenEndpoint
+		client, err := NewTokenClient(tokenEndpoint.TokenUrl, tokenEndpoint.ClientId, tokenEndpoint.ClientSecret, http.DefaultClient)
+		if err != nil {
+			err = fmt.Errorf("failed to initialize user authentication provider: %w", err)
+			return nil, err
+		}
+		return &userTokenProvider{
+			tokenCache:        azureTokenCache,
+			client:            client,
+			usernameAssertion: tokenEndpoint.UsernameAssertion,
+		}, nil
 	default:
-		err = fmt.Errorf("credentials of type '%s' not supported by authentication provider", c.AzureAuthType())
+		err = fmt.Errorf("credentials of type '%s' not supported by Azure authentication provider", c.AzureAuthType())
 		return nil, err
 	}
-
-	tokenProvider := &serviceTokenProvider{
-		tokenCache:     azureTokenCache,
-		tokenRetriever: tokenRetriever,
-	}
-
-	return tokenProvider, nil
 }
 
 type serviceTokenProvider struct {
@@ -76,4 +93,69 @@ func (provider *serviceTokenProvider) GetAccessToken(ctx context.Context, scopes
 		return "", err
 	}
 	return accessToken, nil
+}
+
+type userTokenProvider struct {
+	tokenCache        ConcurrentTokenCache
+	client            TokenClient
+	usernameAssertion bool
+}
+
+func (provider *userTokenProvider) GetAccessToken(ctx context.Context, scopes []string) (string, error) {
+	if ctx == nil {
+		err := fmt.Errorf("parameter 'ctx' cannot be nil")
+		return "", err
+	}
+	if scopes == nil {
+		err := fmt.Errorf("parameter 'scopes' cannot be nil")
+		return "", err
+	}
+
+	currentUser, ok := azusercontext.GetCurrentUser(ctx)
+	if !ok {
+		err := fmt.Errorf("user context not configured")
+		return "", err
+	}
+
+	username, err := extractUsername(currentUser)
+	if err != nil {
+		err := fmt.Errorf("user identity authentication only possible in context of a Grafana user: %w", err)
+		return "", err
+	}
+
+	var tokenRetriever TokenRetriever
+	if provider.usernameAssertion {
+		tokenRetriever = &usernameTokenRetriever{
+			client:   provider.client,
+			username: username,
+		}
+	} else {
+		idToken := currentUser.IdToken
+		if idToken == "" {
+			err := fmt.Errorf("user identity authentication not possible because there's no ID token associated with the Grafana user")
+			return "", err
+		}
+
+		tokenRetriever = &onBehalfOfTokenRetriever{
+			client:  provider.client,
+			userId:  username,
+			idToken: idToken,
+		}
+	}
+
+	accessToken, err := provider.tokenCache.GetAccessToken(ctx, tokenRetriever, scopes)
+	if err != nil {
+		err = fmt.Errorf("unable to acquire access token for user '%s': %w", username, err)
+		return "", err
+	}
+	return accessToken, nil
+}
+
+func extractUsername(userCtx azusercontext.CurrentUserContext) (string, error) {
+	user := userCtx.User
+	if user != nil && user.Login != "" {
+		return user.Login, nil
+	} else {
+		return "", errors.New("request not associated with a Grafana user")
+	}
 }

--- a/aztokenprovider/token_provider.go
+++ b/aztokenprovider/token_provider.go
@@ -19,7 +19,8 @@ type AzureTokenProvider interface {
 	GetAccessToken(ctx context.Context, scopes []string) (string, error)
 }
 
-func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials azcredentials.AzureCredentials) (AzureTokenProvider, error) {
+func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials azcredentials.AzureCredentials,
+	userIdentitySupported bool) (AzureTokenProvider, error) {
 	var err error
 
 	if settings == nil {
@@ -52,6 +53,10 @@ func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials
 			tokenRetriever: tokenRetriever,
 		}, nil
 	case *azcredentials.AadCurrentUserCredentials:
+		if !userIdentitySupported {
+			err = fmt.Errorf("user identity authentication is not supported by this datasource")
+			return nil, err
+		}
 		if !settings.UserIdentityEnabled {
 			err = fmt.Errorf("user identity authentication is not enabled in Grafana config")
 			return nil, err

--- a/aztokenprovider/token_provider_test.go
+++ b/aztokenprovider/token_provider_test.go
@@ -40,6 +40,7 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 
 			provider, err := NewAzureAccessTokenProvider(settings, credentials)
 			require.NoError(t, err)
+			require.IsType(t, &serviceTokenProvider{}, provider)
 
 			getAccessTokenFunc = func(credential TokenRetriever, scopes []string) {
 				assert.IsType(t, &managedIdentityTokenRetriever{}, credential)
@@ -54,6 +55,7 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 
 			provider, err := NewAzureAccessTokenProvider(settings, credentials)
 			require.NoError(t, err)
+			require.IsType(t, &serviceTokenProvider{}, provider)
 
 			getAccessTokenFunc = func(credential TokenRetriever, scopes []string) {
 				assert.IsType(t, &clientSecretTokenRetriever{}, credential)
@@ -73,67 +75,5 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 			_, err := NewAzureAccessTokenProvider(settings, credentials)
 			assert.Error(t, err, "managed identity authentication is not enabled in Grafana config")
 		})
-	})
-}
-
-func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
-	defaultCredentials := func() *azcredentials.AzureClientSecretCredentials {
-		return &azcredentials.AzureClientSecretCredentials{
-			AzureCloud:   azsettings.AzurePublic,
-			Authority:    "",
-			TenantId:     "7dcf1d1a-4ec0-41f2-ac29-c1538a698bc4",
-			ClientId:     "1af7c188-e5b6-4f96-81b8-911761bdd459",
-			ClientSecret: "0416d95e-8af8-472c-aaa3-15c93c46080a",
-		}
-	}
-
-	t.Run("should return clientSecretTokenRetriever with values", func(t *testing.T) {
-		credentials := defaultCredentials()
-
-		result, err := getClientSecretTokenRetriever(credentials)
-		require.NoError(t, err)
-
-		assert.IsType(t, &clientSecretTokenRetriever{}, result)
-		credential := (result).(*clientSecretTokenRetriever)
-
-		assert.Equal(t, "https://login.microsoftonline.com/", credential.cloudConf.ActiveDirectoryAuthorityHost)
-		assert.Equal(t, "7dcf1d1a-4ec0-41f2-ac29-c1538a698bc4", credential.tenantId)
-		assert.Equal(t, "1af7c188-e5b6-4f96-81b8-911761bdd459", credential.clientId)
-		assert.Equal(t, "0416d95e-8af8-472c-aaa3-15c93c46080a", credential.clientSecret)
-	})
-
-	t.Run("authority should selected based on cloud", func(t *testing.T) {
-		credentials := defaultCredentials()
-		credentials.AzureCloud = azsettings.AzureChina
-
-		result, err := getClientSecretTokenRetriever(credentials)
-		require.NoError(t, err)
-
-		assert.IsType(t, &clientSecretTokenRetriever{}, result)
-		credential := (result).(*clientSecretTokenRetriever)
-
-		assert.Equal(t, "https://login.chinacloudapi.cn/", credential.cloudConf.ActiveDirectoryAuthorityHost)
-	})
-
-	t.Run("explicitly set authority should have priority over cloud", func(t *testing.T) {
-		credentials := defaultCredentials()
-		credentials.AzureCloud = azsettings.AzureChina
-		credentials.Authority = "https://another.com/"
-
-		result, err := getClientSecretTokenRetriever(credentials)
-		require.NoError(t, err)
-
-		assert.IsType(t, &clientSecretTokenRetriever{}, result)
-		credential := (result).(*clientSecretTokenRetriever)
-
-		assert.Equal(t, "https://another.com/", credential.cloudConf.ActiveDirectoryAuthorityHost)
-	})
-
-	t.Run("should fail with error if cloud is not supported", func(t *testing.T) {
-		credentials := defaultCredentials()
-		credentials.AzureCloud = "InvalidCloud"
-
-		_, err := getClientSecretTokenRetriever(credentials)
-		require.Error(t, err)
 	})
 }

--- a/aztokenprovider/token_provider_test.go
+++ b/aztokenprovider/token_provider_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/grafana/grafana-azure-sdk-go/azusercontext"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +21,7 @@ func (c *tokenCacheFake) GetAccessToken(_ context.Context, credential TokenRetri
 	return "4cb83b87-0ffb-4abd-82f6-48a8c08afc53", nil
 }
 
-func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
+func TestNewAzureAccessTokenProvider_ServiceIdentity(t *testing.T) {
 	ctx := context.Background()
 
 	settings := &azsettings.AzureSettings{}
@@ -38,7 +40,7 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 		t.Run("should resolve managed identity retriever if auth type is managed identity", func(t *testing.T) {
 			credentials := &azcredentials.AzureManagedIdentityCredentials{}
 
-			provider, err := NewAzureAccessTokenProvider(settings, credentials)
+			provider, err := NewAzureAccessTokenProvider(settings, credentials, false)
 			require.NoError(t, err)
 			require.IsType(t, &serviceTokenProvider{}, provider)
 
@@ -53,7 +55,7 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 		t.Run("should resolve client secret retriever if auth type is client secret", func(t *testing.T) {
 			credentials := &azcredentials.AzureClientSecretCredentials{AzureCloud: azsettings.AzurePublic}
 
-			provider, err := NewAzureAccessTokenProvider(settings, credentials)
+			provider, err := NewAzureAccessTokenProvider(settings, credentials, false)
 			require.NoError(t, err)
 			require.IsType(t, &serviceTokenProvider{}, provider)
 
@@ -72,8 +74,140 @@ func TestAzureTokenProvider_GetAccessToken(t *testing.T) {
 		t.Run("should return error if auth type is managed identity", func(t *testing.T) {
 			credentials := &azcredentials.AzureManagedIdentityCredentials{}
 
-			_, err := NewAzureAccessTokenProvider(settings, credentials)
+			_, err := NewAzureAccessTokenProvider(settings, credentials, false)
 			assert.Error(t, err, "managed identity authentication is not enabled in Grafana config")
 		})
+	})
+}
+
+func TestNewAzureAccessTokenProvider_UserIdentity(t *testing.T) {
+	settingsNotConfigured := &azsettings.AzureSettings{}
+
+	settings := &azsettings.AzureSettings{
+		UserIdentityEnabled: true,
+		UserIdentityTokenEndpoint: &azsettings.TokenEndpointSettings{
+			TokenUrl:     "FAKE_TOKEN_URL",
+			ClientId:     "FAKE_CLIENT_ID",
+			ClientSecret: "FAKE_CLIENT_SECRET",
+		},
+	}
+
+	t.Run("should fail when user identity not supported", func(t *testing.T) {
+		credentials := &azcredentials.AadCurrentUserCredentials{}
+
+		_, err := NewAzureAccessTokenProvider(settingsNotConfigured, credentials, false)
+		assert.Error(t, err)
+	})
+
+	t.Run("should fail when user identity not configured", func(t *testing.T) {
+		credentials := &azcredentials.AadCurrentUserCredentials{}
+
+		_, err := NewAzureAccessTokenProvider(settingsNotConfigured, credentials, true)
+		assert.Error(t, err)
+	})
+
+	t.Run("should return user provider when user identity configured", func(t *testing.T) {
+		credentials := &azcredentials.AadCurrentUserCredentials{}
+
+		provider, err := NewAzureAccessTokenProvider(settings, credentials, true)
+		require.NoError(t, err)
+		require.IsType(t, &userTokenProvider{}, provider)
+	})
+}
+
+func TestGetAccessToken_UserIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	scopes := []string{
+		"https://management.azure.com/.default",
+	}
+
+	var err error
+
+	t.Run("should fail if user context not configured", func(t *testing.T) {
+		var provider AzureTokenProvider = &userTokenProvider{
+			tokenCache: &tokenCacheFake{},
+		}
+
+		getAccessTokenFunc = func(retriever TokenRetriever, scopes []string) {
+			assert.IsType(t, &onBehalfOfTokenRetriever{}, retriever)
+		}
+
+		_, err = provider.GetAccessToken(ctx, scopes)
+		assert.Error(t, err)
+	})
+
+	t.Run("should fail if no user in user context", func(t *testing.T) {
+		var provider AzureTokenProvider = &userTokenProvider{
+			tokenCache: &tokenCacheFake{},
+		}
+
+		getAccessTokenFunc = func(retriever TokenRetriever, scopes []string) {
+			assert.IsType(t, &onBehalfOfTokenRetriever{}, retriever)
+		}
+
+		usrctx := azusercontext.WithCurrentUser(ctx, azusercontext.CurrentUserContext{})
+
+		_, err = provider.GetAccessToken(usrctx, scopes)
+		assert.Error(t, err)
+	})
+
+	t.Run("should fail if no ID token in user context", func(t *testing.T) {
+		var provider AzureTokenProvider = &userTokenProvider{
+			tokenCache: &tokenCacheFake{},
+		}
+
+		getAccessTokenFunc = func(retriever TokenRetriever, scopes []string) {
+			assert.IsType(t, &onBehalfOfTokenRetriever{}, retriever)
+		}
+
+		usrctx := azusercontext.WithCurrentUser(ctx, azusercontext.CurrentUserContext{
+			User: &backend.User{
+				Login: "user1@example.org",
+			},
+		})
+
+		_, err = provider.GetAccessToken(usrctx, scopes)
+		assert.Error(t, err)
+	})
+
+	t.Run("should use onBehalfOfTokenRetriever by default", func(t *testing.T) {
+		var provider AzureTokenProvider = &userTokenProvider{
+			tokenCache: &tokenCacheFake{},
+		}
+
+		getAccessTokenFunc = func(retriever TokenRetriever, scopes []string) {
+			assert.IsType(t, &onBehalfOfTokenRetriever{}, retriever)
+		}
+
+		usrctx := azusercontext.WithCurrentUser(ctx, azusercontext.CurrentUserContext{
+			User: &backend.User{
+				Login: "user1@example.org",
+			},
+			IdToken: "FAKE_ID_TOKEN",
+		})
+
+		_, err = provider.GetAccessToken(usrctx, scopes)
+		require.NoError(t, err)
+	})
+
+	t.Run("should use usernameTokenRetriever for usernameAssertion", func(t *testing.T) {
+		var provider AzureTokenProvider = &userTokenProvider{
+			tokenCache:        &tokenCacheFake{},
+			usernameAssertion: true,
+		}
+
+		getAccessTokenFunc = func(retriever TokenRetriever, scopes []string) {
+			assert.IsType(t, &usernameTokenRetriever{}, retriever)
+		}
+
+		usrctx := azusercontext.WithCurrentUser(ctx, azusercontext.CurrentUserContext{
+			User: &backend.User{
+				Login: "user1@example.org",
+			},
+		})
+
+		_, err = provider.GetAccessToken(usrctx, scopes)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This PR extends functionality of Azure token provider to support user identity authentication based on introduced earlier `azcredentials.AadCurrentUserCredentials` and user identity settings in `azsettings.AzureSettings`.

Original `token_provider.go` was refactored and token retrievers were moved into separated files `retriever_msi.go`, `retriever_clientsecret.go`. Implementation of `aztokenprovider.AzureTokenProvider` was split into two `serviceTokenProvider` and `userTokenProvider`, former is for user-agnostic service identities and the later is for user identities. They have different implementation of `GetAccessToken` func.

`NewAzureAccessTokenProvider` creates a new instance of `serviceTokenProvider` or `userTokenProvider` depending on type of credentials provided.

For user identity authentication to work:
- it needs to be configured in Grafana config (see https://github.com/grafana/grafana/pull/50277)
- it needs to be supported and allowed by the datasource.

Example of Azure configuration in datasource code ([here](https://github.com/grafana/azure-data-explorer-datasource/blob/2a7d4df60861a5ce147aa3d49a5a873a72cbdeb3/pkg/azuredx/client/httpclient.go#L17)):

```go
authOpts := azhttpclient.NewAuthOptions(azureSettings)

// Allow user identity authentication for this datasource if it's configured in Grafana config
authOpts.AllowUserIdentity()

azhttpclient.AddAzureAuthentication(&clientOpts, authOpts, credentials)

httpClient, err := httpclient.NewProvider().New(clientOpts)
```

Fixes #6