### PR TITLE
Support for allowed endpoints

### DIFF
--- a/azhttpclient/internal/azendpoint/allowlist.go
+++ b/azhttpclient/internal/azendpoint/allowlist.go
@@ -1,0 +1,132 @@
+package azendpoint
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type EndpointAllowlist struct {
+	entries []allowEntry
+}
+
+type allowEntry struct {
+	scheme string
+	port   string
+	host   string
+	suffix bool
+}
+
+func Allowlist(allowedEndpoints []string) (*EndpointAllowlist, error) {
+	var entries = make([]allowEntry, len(allowedEndpoints))
+
+	for i, endpointStr := range allowedEndpoints {
+		u, err := url.Parse(endpointStr)
+		if err != nil {
+			err = fmt.Errorf("invalid allow endpoint: %w", err)
+			return nil, err
+		}
+
+		allowedScheme := u.Scheme
+		allowedHost := u.Hostname()
+
+		allowedPort := explicitPort(u)
+		if allowedPort == "" {
+			err = fmt.Errorf("invalid allow endpoint '%s': scheme '%s' requires explicit port", endpointStr, u.Scheme)
+			return nil, err
+		}
+
+		if len(allowedHost) > 2 && strings.HasPrefix(allowedHost, "*.") {
+			entries[i] = allowEntry{
+				scheme: allowedScheme,
+				port:   allowedPort,
+				host:   allowedHost[1:],
+				suffix: true,
+			}
+		} else {
+			entries[i] = allowEntry{
+				scheme: allowedScheme,
+				port:   allowedPort,
+				host:   allowedHost,
+				suffix: false,
+			}
+		}
+	}
+
+	return &EndpointAllowlist{
+		entries: entries,
+	}, nil
+}
+
+func (v *EndpointAllowlist) IsAllowed(endpoint *url.URL) bool {
+	if endpoint == nil {
+		return false
+	}
+
+	scheme := endpoint.Scheme
+	if scheme == "" {
+		return false
+	}
+
+	host := endpoint.Hostname()
+	if host == "" {
+		return false
+	}
+
+	port := explicitPort(endpoint)
+
+	for _, entry := range v.entries {
+		if v.matchEntry(entry, scheme, host, port) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (v *EndpointAllowlist) matchEntry(allowEntry allowEntry, scheme string, host string, port string) bool {
+	// Scheme
+	if scheme != allowEntry.scheme {
+		return false
+	}
+
+	// Port
+	if allowEntry.port != "*" && (port == "" || port != allowEntry.port) {
+		return false
+	}
+
+	// Host
+	if !allowEntry.suffix {
+		if strings.ToLower(host) == allowEntry.host {
+			return true
+		}
+	} else {
+		hostLen := len(host)
+		allowSuffixLen := len(allowEntry.host)
+		// Host should be longer than suffix (not equal)
+		if hostLen > allowSuffixLen {
+			if strings.ToLower(host[hostLen-allowSuffixLen:]) == allowEntry.host {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+var knownPorts = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+func explicitPort(u *url.URL) string {
+	port := u.Port()
+
+	if port == "" {
+		if knownPort, ok := knownPorts[u.Scheme]; ok {
+			port = knownPort
+		}
+	}
+
+	return port
+}

--- a/azhttpclient/internal/azendpoint/allowlist_test.go
+++ b/azhttpclient/internal/azendpoint/allowlist_test.go
@@ -1,0 +1,309 @@
+package azendpoint
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowlist(t *testing.T) {
+	t.Run("given invalid allowlist", func(t *testing.T) {
+		t.Run("should not accept empty string", func(t *testing.T) {
+			_, err := Allowlist([]string{
+				"",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("should not accept plain hostname", func(t *testing.T) {
+			_, err := Allowlist([]string{
+				"example.net",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("should not accept relative path", func(t *testing.T) {
+			_, err := Allowlist([]string{
+				"/foobar",
+			})
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("given exact scheme", func(t *testing.T) {
+		a, err := Allowlist([]string{
+			"https://example.com",
+			"svc://example.net:5001",
+		})
+		require.NoError(t, err)
+
+		t.Run("should match https scheme", func(t *testing.T) {
+			u, err := url.Parse("https://example.com")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match custom scheme", func(t *testing.T) {
+			u, err := url.Parse("svc://example.net:5001")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should not match http instead of https", func(t *testing.T) {
+			u, err := url.Parse("http://example.com")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not match different scheme", func(t *testing.T) {
+			u, err := url.Parse("https://example.net:5001")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+	})
+
+	t.Run("do not support wildcard scheme", func(t *testing.T) {
+		_, err := Allowlist([]string{
+			"*://example.net",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("do not support omitted scheme", func(t *testing.T) {
+		_, err := Allowlist([]string{
+			"://example.net",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("given exact port", func(t *testing.T) {
+		a, err := Allowlist([]string{
+			"http://example.org:80",
+			"https://example.com:443",
+			"https://example1.net:3000",
+			"svc://example2.net:5001",
+		})
+		require.NoError(t, err)
+
+		t.Run("should match exact port", func(t *testing.T) {
+			u, err := url.Parse("https://example1.net:3000")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match http without port", func(t *testing.T) {
+			u, err := url.Parse("http://example.org")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match https without port", func(t *testing.T) {
+			u, err := url.Parse("https://example.com")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should not match https with custom port to https without port", func(t *testing.T) {
+			u, err := url.Parse("https://example1.net")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not match custom scheme without port", func(t *testing.T) {
+			u, err := url.Parse("svc://example2.net")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not match different port", func(t *testing.T) {
+			u, err := url.Parse("svc://example2.net:555")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+	})
+
+	t.Run("given no port for known scheme", func(t *testing.T) {
+		a, err := Allowlist([]string{
+			"http://example.org",
+			"https://example.com",
+		})
+		require.NoError(t, err)
+
+		t.Run("should match http without port", func(t *testing.T) {
+			u, err := url.Parse("http://example.org")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match https without port", func(t *testing.T) {
+			u, err := url.Parse("https://example.com")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match http with port", func(t *testing.T) {
+			u, err := url.Parse("http://example.org:80")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match https with port", func(t *testing.T) {
+			u, err := url.Parse("https://example.com:443")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should not match different port", func(t *testing.T) {
+			u, err := url.Parse("http://example.org:5001")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not match http port for https", func(t *testing.T) {
+			u, err := url.Parse("https://example.com:80")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+	})
+
+	t.Run("should require port for custom scheme", func(t *testing.T) {
+		_, err := Allowlist([]string{
+			"tcp://example.net",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("do not support wildcard port", func(t *testing.T) {
+		_, err := Allowlist([]string{
+			"tcp://example.net:*",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("given host", func(t *testing.T) {
+		a, err := Allowlist([]string{
+			"https://example.com",
+			"https://*.example.net",
+		})
+		require.NoError(t, err)
+
+		t.Run("should not allow empty string", func(t *testing.T) {
+			ok := a.IsAllowed(nil)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not allow invalid url", func(t *testing.T) {
+			u, err := url.Parse("/test")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not allow empty host", func(t *testing.T) {
+			u, err := url.Parse("svc:///test")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not allow localhost", func(t *testing.T) {
+			u, err := url.Parse("https://localhost/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not allow unknown domain", func(t *testing.T) {
+			u, err := url.Parse("https://unknown.com/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should match exact allowed domain", func(t *testing.T) {
+			u, err := url.Parse("https://example.com/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should not match subdomain of exact allowed domain", func(t *testing.T) {
+			u, err := url.Parse("https://subdomain.example.com/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should match allowed suffix", func(t *testing.T) {
+			u, err := url.Parse("https://test.example.net/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should match allowed suffix with nested subdomains", func(t *testing.T) {
+			u, err := url.Parse("https://test.subdomain.example.net/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.True(t, ok)
+		})
+
+		t.Run("should not match allowed suffix without subdomain", func(t *testing.T) {
+			u, err := url.Parse("https://example.net/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+
+		t.Run("should not match allowed suffix with dot", func(t *testing.T) {
+			u, err := url.Parse("https://.example.net/")
+			require.NoError(t, err)
+
+			ok := a.IsAllowed(u)
+			assert.False(t, ok)
+		})
+	})
+}

--- a/azhttpclient/internal/azendpoint/endpoint.go
+++ b/azhttpclient/internal/azendpoint/endpoint.go
@@ -1,0 +1,16 @@
+package azendpoint
+
+import (
+	"net/url"
+)
+
+func Endpoint(u url.URL) *url.URL {
+	if u.Opaque != "" || u.Scheme == "" || u.Host == "" {
+		return nil
+	}
+
+	return &url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+	}
+}

--- a/azhttpclient/internal/azendpoint/endpoint_test.go
+++ b/azhttpclient/internal/azendpoint/endpoint_test.go
@@ -1,0 +1,38 @@
+package azendpoint
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoint(t *testing.T) {
+	t.Run("should return nil for url without host", func(t *testing.T) {
+		u, err := url.Parse("svc:///test")
+		require.NoError(t, err)
+
+		e := Endpoint(*u)
+
+		assert.Nil(t, e)
+	})
+
+	t.Run("should return endpoint without path and query string", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/api/query?q=foobar&l=1")
+		require.NoError(t, err)
+
+		e := Endpoint(*u)
+
+		assert.Equal(t, "https://example.com", e.String())
+	})
+
+	t.Run("should not modify original url", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/api/query?q=foobar&l=1")
+		require.NoError(t, err)
+
+		_ = Endpoint(*u)
+
+		assert.Equal(t, "https://example.com/api/query?q=foobar&l=1", u.String())
+	})
+}

--- a/azhttpclient/options.go
+++ b/azhttpclient/options.go
@@ -2,6 +2,7 @@ package azhttpclient
 
 import (
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/azhttpclient/internal/azendpoint"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/aztokenprovider"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -11,6 +12,7 @@ type AzureTokenProviderFactory = func(*azsettings.AzureSettings, azcredentials.A
 
 type AuthOptions struct {
 	settings              *azsettings.AzureSettings
+	endpoints             *azendpoint.EndpointAllowlist
 	scopes                []string
 	userIdentitySupported bool
 	customProviders       map[string]AzureTokenProviderFactory
@@ -33,6 +35,15 @@ func (opts *AuthOptions) Scopes(scopes []string) {
 			}
 		}
 	}
+}
+
+func (opts *AuthOptions) AllowedEndpoints(endpoints []string) error {
+	if allowlist, err := azendpoint.Allowlist(endpoints); err != nil {
+		return err
+	} else {
+		opts.endpoints = allowlist
+	}
+	return nil
 }
 
 func (opts *AuthOptions) AllowUserIdentity() {


### PR DESCRIPTION
This PR allows datasources to optionally enforce specific endpoints to be allowed when using Azure authentication.

It adds a new method `authOpts.AllowedEndpoints(endpoints)` which accepts a list of endpoints.

Endpoints can either point to exact host or to wildcard domain:
```go
endpoints := []string {
	"https://management.azure.com",
	"https://*.kusto.windows.net",
}
```

Usage in datasource:

```go
authOpts := azhttpclient.NewAuthOptions(azureSettings)

// Configure allowed endpoints
err = authOpts.AllowedEndpoints(endpoints)
if err != nil {
	return nil, err
}

authOpts.Scopes(scopes)

clientOpts, err := instanceSettings.HTTPClientOptions()
azhttpclient.AddAzureAuthentication(&clientOpts, authOpts, credentials)

httpClient, err := httpclient.NewProvider().New(clientOpts)
```

#### Implementation

The endpoint matching logic is implemented in the new `azendpoint.EndpointAllowlist` but it internal and not yet exposed to end users because its contract and behavior may change.
