### PR TITLE
Incorporate tenant id in token cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Common Azure configuration.
 ### azcredentials
 
 The built-in `AzureCredentials`:
+
 - `AadCurrentUserCredentials`
 - `AzureManagedIdentityCredentials`
 - `AzureClientSecretCredentials`
@@ -46,16 +47,18 @@ httpClient, err := httpclient.NewProvider().New(clientOpts)
 Context object `CurrentUserContext` of the currently signed-in Grafana user which can be passed
 via context between business layers.
 
-Used by token provider to get information about the current user for user identity authentication. 
+Used by token provider to get information about the current user for user identity authentication.
 
 Read/write functions:
+
 - `context = azusercontext.WithCurrentUser(context, currentUser)` extends given context with information about the current user.
-- `currentUser = azusercontext..GetCurrentUser(context)` extracts current user from the given context
+- `currentUser = azusercontext.GetCurrentUser(context)` extracts current user from the given context
 
 Helper functions for datasource requests:
-- `WithUserFromQueryReq` extracts current user from query request and adds to context. 
+
+- `WithUserFromQueryReq` extracts current user from query request and adds to context.
 - `WithUserFromResourceReq` extracts current user from resource call and adds to context.
-- `WithUserFromHealthCheckReq` extracts current from health check request and adds to context. 
+- `WithUserFromHealthCheckReq` extracts current from health check request and adds to context.
 
 ### aztokenprovider
 

--- a/aztokenprovider/retriever_clientsecret.go
+++ b/aztokenprovider/retriever_clientsecret.go
@@ -40,8 +40,8 @@ func getClientSecretTokenRetriever(credentials *azcredentials.AzureClientSecretC
 	}, nil
 }
 
-func (c *clientSecretTokenRetriever) GetCacheKey() string {
-	return fmt.Sprintf("azure|clientsecret|%s|%s|%s|%s", c.cloudConf.ActiveDirectoryAuthorityHost, c.tenantId, c.clientId, hashSecret(c.clientSecret))
+func (c *clientSecretTokenRetriever) GetCacheKey(multiTenantID string) string {
+	return fmt.Sprintf("azure|clientsecret|%s|%s|%s|%s|%s", c.cloudConf.ActiveDirectoryAuthorityHost, c.tenantId, c.clientId, hashSecret(c.clientSecret), multiTenantID)
 }
 
 func (c *clientSecretTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_clientsecret.go
+++ b/aztokenprovider/retriever_clientsecret.go
@@ -40,8 +40,8 @@ func getClientSecretTokenRetriever(credentials *azcredentials.AzureClientSecretC
 	}, nil
 }
 
-func (c *clientSecretTokenRetriever) GetCacheKey(multiTenantID string) string {
-	return fmt.Sprintf("azure|clientsecret|%s|%s|%s|%s|%s", c.cloudConf.ActiveDirectoryAuthorityHost, c.tenantId, c.clientId, hashSecret(c.clientSecret), multiTenantID)
+func (c *clientSecretTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
+	return fmt.Sprintf("azure|clientsecret|%s|%s|%s|%s|%s", c.cloudConf.ActiveDirectoryAuthorityHost, c.tenantId, c.clientId, hashSecret(c.clientSecret), grafanaMultiTenantId)
 }
 
 func (c *clientSecretTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_msi.go
+++ b/aztokenprovider/retriever_msi.go
@@ -28,12 +28,12 @@ func getManagedIdentityTokenRetriever(settings *azsettings.AzureSettings, creden
 	}
 }
 
-func (c *managedIdentityTokenRetriever) GetCacheKey(multiTenantID string) string {
+func (c *managedIdentityTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
 	clientId := c.clientId
 	if clientId == "" {
 		clientId = "system"
 	}
-	return fmt.Sprintf("azure|msi|%s|%s", clientId, multiTenantID)
+	return fmt.Sprintf("azure|msi|%s|%s", clientId, grafanaMultiTenantId)
 }
 
 func (c *managedIdentityTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_msi.go
+++ b/aztokenprovider/retriever_msi.go
@@ -28,12 +28,12 @@ func getManagedIdentityTokenRetriever(settings *azsettings.AzureSettings, creden
 	}
 }
 
-func (c *managedIdentityTokenRetriever) GetCacheKey() string {
+func (c *managedIdentityTokenRetriever) GetCacheKey(multiTenantID string) string {
 	clientId := c.clientId
 	if clientId == "" {
 		clientId = "system"
 	}
-	return fmt.Sprintf("azure|msi|%s", clientId)
+	return fmt.Sprintf("azure|msi|%s|%s", clientId, multiTenantID)
 }
 
 func (c *managedIdentityTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -11,8 +11,8 @@ type onBehalfOfTokenRetriever struct {
 	idToken string
 }
 
-func (r *onBehalfOfTokenRetriever) GetCacheKey() string {
-	return fmt.Sprintf("currentuser|idtoken|%s", r.userId)
+func (r *onBehalfOfTokenRetriever) GetCacheKey(multiTenantID string) string {
+	return fmt.Sprintf("currentuser|idtoken|%s|%s", r.userId, multiTenantID)
 }
 
 func (r *onBehalfOfTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -11,8 +11,8 @@ type onBehalfOfTokenRetriever struct {
 	idToken string
 }
 
-func (r *onBehalfOfTokenRetriever) GetCacheKey(multiTenantID string) string {
-	return fmt.Sprintf("currentuser|idtoken|%s|%s", r.userId, multiTenantID)
+func (r *onBehalfOfTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
+	return fmt.Sprintf("currentuser|idtoken|%s|%s", r.userId, grafanaMultiTenantId)
 }
 
 func (r *onBehalfOfTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_username.go
+++ b/aztokenprovider/retriever_username.go
@@ -10,8 +10,8 @@ type usernameTokenRetriever struct {
 	username string
 }
 
-func (r *usernameTokenRetriever) GetCacheKey(multiTenantID string) string {
-	return fmt.Sprintf("currentuser|username|%s|%s", r.username, multiTenantID)
+func (r *usernameTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
+	return fmt.Sprintf("currentuser|username|%s|%s", r.username, grafanaMultiTenantId)
 }
 
 func (r *usernameTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_username.go
+++ b/aztokenprovider/retriever_username.go
@@ -10,8 +10,8 @@ type usernameTokenRetriever struct {
 	username string
 }
 
-func (r *usernameTokenRetriever) GetCacheKey() string {
-	return fmt.Sprintf("currentuser|username|%s", r.username)
+func (r *usernameTokenRetriever) GetCacheKey(multiTenantID string) string {
+	return fmt.Sprintf("currentuser|username|%s|%s", r.username, multiTenantID)
 }
 
 func (r *usernameTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_workloadidentity.go
+++ b/aztokenprovider/retriever_workloadidentity.go
@@ -36,7 +36,7 @@ func getWorkloadIdentityTokenRetriever(settings *azsettings.AzureSettings, crede
 	}
 }
 
-func (c *workloadIdentityTokenRetriever) GetCacheKey() string {
+func (c *workloadIdentityTokenRetriever) GetCacheKey(multiTenantID string) string {
 	tenantId := c.tenantId
 	if tenantId == "" {
 		tenantId = "default"
@@ -46,7 +46,7 @@ func (c *workloadIdentityTokenRetriever) GetCacheKey() string {
 		clientId = "default"
 	}
 
-	return fmt.Sprintf("azure|wi|%s|%s", tenantId, clientId)
+	return fmt.Sprintf("azure|wi|%s|%s|%s", tenantId, clientId, multiTenantID)
 }
 
 func (c *workloadIdentityTokenRetriever) Init() error {

--- a/aztokenprovider/retriever_workloadidentity.go
+++ b/aztokenprovider/retriever_workloadidentity.go
@@ -36,7 +36,7 @@ func getWorkloadIdentityTokenRetriever(settings *azsettings.AzureSettings, crede
 	}
 }
 
-func (c *workloadIdentityTokenRetriever) GetCacheKey(multiTenantID string) string {
+func (c *workloadIdentityTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
 	tenantId := c.tenantId
 	if tenantId == "" {
 		tenantId = "default"
@@ -46,7 +46,7 @@ func (c *workloadIdentityTokenRetriever) GetCacheKey(multiTenantID string) strin
 		clientId = "default"
 	}
 
-	return fmt.Sprintf("azure|wi|%s|%s|%s", tenantId, clientId, multiTenantID)
+	return fmt.Sprintf("azure|wi|%s|%s|%s", tenantId, clientId, grafanaMultiTenantId)
 }
 
 func (c *workloadIdentityTokenRetriever) Init() error {

--- a/aztokenprovider/token_cache.go
+++ b/aztokenprovider/token_cache.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const tenantKey = "tenantID"
+const grafanaTenantId = "tenantID"
 
 var (
 	// timeNow makes it possible to test usage of time
@@ -196,7 +196,7 @@ func returnGrafanaMultiTenantId(ctx context.Context) (grafanaMultiTenantId strin
 	md, exists := metadata.FromIncomingContext(ctx)
 
 	if exists {
-		tid := md.Get(tenantKey)
+		tid := md.Get(grafanaTenantId)
 		if len(tid) > 0 && tid[0] != "" {
 			grafanaMultiTenantId = tid[0]
 		}

--- a/aztokenprovider/token_cache.go
+++ b/aztokenprovider/token_cache.go
@@ -24,7 +24,7 @@ type AccessToken struct {
 }
 
 type TokenRetriever interface {
-	GetCacheKey(multiTenantID string) string
+	GetCacheKey(grafanaMultiTenantId string) string
 	Init() error
 	GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error)
 }
@@ -64,7 +64,7 @@ func (c *tokenCacheImpl) GetAccessToken(ctx context.Context, tokenRetriever Toke
 func (c *tokenCacheImpl) getEntryFor(ctx context.Context, credential TokenRetriever) *credentialCacheEntry {
 	var entry interface{}
 	var ok bool
-	tid := returnMultiTenantId(ctx)
+	tid := returnGrafanaMultiTenantId(ctx)
 
 	key := credential.GetCacheKey(tid)
 	if entry, ok = c.cache.Load(key); !ok {
@@ -192,15 +192,15 @@ func getKeyForScopes(scopes []string) string {
 	return strings.Join(scopes, " ")
 }
 
-func returnMultiTenantId(ctx context.Context) (multiTenantId string) {
+func returnGrafanaMultiTenantId(ctx context.Context) (grafanaMultiTenantId string) {
 	md, exists := metadata.FromIncomingContext(ctx)
 
 	if exists {
 		tid := md.Get(tenantKey)
 		if len(tid) > 0 && tid[0] != "" {
-			multiTenantId = tid[0]
+			grafanaMultiTenantId = tid[0]
 		}
 	}
 
-	return multiTenantId
+	return grafanaMultiTenantId
 }

--- a/aztokenprovider/token_cache.go
+++ b/aztokenprovider/token_cache.go
@@ -7,7 +7,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/grpc/metadata"
 )
+
+const tenantKey = "tenantID"
 
 var (
 	// timeNow makes it possible to test usage of time
@@ -20,7 +24,7 @@ type AccessToken struct {
 }
 
 type TokenRetriever interface {
-	GetCacheKey() string
+	GetCacheKey(multiTenantID string) string
 	Init() error
 	GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error)
 }
@@ -54,15 +58,15 @@ type scopesCacheEntry struct {
 }
 
 func (c *tokenCacheImpl) GetAccessToken(ctx context.Context, tokenRetriever TokenRetriever, scopes []string) (string, error) {
-	return c.getEntryFor(tokenRetriever).getAccessToken(ctx, scopes)
+	return c.getEntryFor(ctx, tokenRetriever).getAccessToken(ctx, scopes)
 }
 
-func (c *tokenCacheImpl) getEntryFor(credential TokenRetriever) *credentialCacheEntry {
+func (c *tokenCacheImpl) getEntryFor(ctx context.Context, credential TokenRetriever) *credentialCacheEntry {
 	var entry interface{}
 	var ok bool
+	tid := returnMultiTenantId(ctx)
 
-	key := credential.GetCacheKey()
-
+	key := credential.GetCacheKey(tid)
 	if entry, ok = c.cache.Load(key); !ok {
 		entry, _ = c.cache.LoadOrStore(key, &credentialCacheEntry{
 			retriever: credential,
@@ -186,4 +190,17 @@ func getKeyForScopes(scopes []string) string {
 	}
 
 	return strings.Join(scopes, " ")
+}
+
+func returnMultiTenantId(ctx context.Context) (multiTenantId string) {
+	md, exists := metadata.FromIncomingContext(ctx)
+
+	if exists {
+		tid := md.Get(tenantKey)
+		if len(tid) > 0 && tid[0] != "" {
+			multiTenantId = tid[0]
+		}
+	}
+
+	return multiTenantId
 }

--- a/aztokenprovider/token_cache_test.go
+++ b/aztokenprovider/token_cache_test.go
@@ -20,7 +20,7 @@ type fakeRetriever struct {
 	getAccessTokenFunc func(ctx context.Context, scopes []string) (*AccessToken, error)
 }
 
-func (c *fakeRetriever) GetCacheKey() string {
+func (c *fakeRetriever) GetCacheKey(multiTenantID string) string {
 	return c.key
 }
 

--- a/aztokenprovider/token_cache_test.go
+++ b/aztokenprovider/token_cache_test.go
@@ -20,7 +20,7 @@ type fakeRetriever struct {
 	getAccessTokenFunc func(ctx context.Context, scopes []string) (*AccessToken, error)
 }
 
-func (c *fakeRetriever) GetCacheKey(multiTenantID string) string {
+func (c *fakeRetriever) GetCacheKey(grafanaMultiTenantId string) string {
 	return c.key
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
 	github.com/grafana/grafana-plugin-sdk-go v0.178.0
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/grpc v1.41.0
 )
 
 require (


### PR DESCRIPTION
The plugin sdk added the tenant id to the metadata in https://github.com/grafana/grafana-plugin-sdk-go/pull/676 this adopts that work and incorporates it into the cache key.

To verify you can use our [test environment](https://github.com/grafana/oss-plugin-partnerships/tree/simpson-multi-docker/multi-tenant-env). Read more about the tenant ID in this [doc](https://docs.google.com/document/d/1EEh0KLnjIe_qizvNw_Wt4LaYJQcaBYKY5Fl-IMMiCzY/edit?usp=sharing).

Closes https://github.com/grafana/oss-plugin-partnerships/issues/240