### PR TITLE
Dependabot reviewer

### DIFF
--- a/.github/dependabot-reviewer.yml
+++ b/.github/dependabot-reviewer.yml
@@ -1,0 +1,15 @@
+name: Dependabot reviewer
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  call-workflow-passing-data:
+    uses: grafana/security-github-actions/.github/workflows/dependabot-automerge.yaml@main
+    # with:
+    #  Add this to define production packages that dependabot can auto-update if the bump is minor
+    #  packages-minor-autoupdate: '[]'
+    secrets: inherit


### PR DESCRIPTION
Add automated dependabot reviewer. The reviewer will auto-merge dependabot PR's for; patch updates to dev or prod dependencies, minor updates to dev dependencies, and minor updates to a whitelisted prod dependency.