### PR TITLE
Cloud settings in Azure token provider

### DIFF
--- a/aztokenprovider/retriever_clientsecret_test.go
+++ b/aztokenprovider/retriever_clientsecret_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
+	var settings = &azsettings.AzureSettings{
+		Cloud: azsettings.AzurePublic,
+	}
+
 	defaultCredentials := func() *azcredentials.AzureClientSecretCredentials {
 		return &azcredentials.AzureClientSecretCredentials{
 			AzureCloud:   azsettings.AzurePublic,
@@ -23,7 +27,7 @@ func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
 	t.Run("should return clientSecretTokenRetriever with values", func(t *testing.T) {
 		credentials := defaultCredentials()
 
-		result, err := getClientSecretTokenRetriever(credentials)
+		result, err := getClientSecretTokenRetriever(settings, credentials)
 		require.NoError(t, err)
 
 		assert.IsType(t, &clientSecretTokenRetriever{}, result)
@@ -39,7 +43,7 @@ func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
 		credentials := defaultCredentials()
 		credentials.AzureCloud = azsettings.AzureChina
 
-		result, err := getClientSecretTokenRetriever(credentials)
+		result, err := getClientSecretTokenRetriever(settings, credentials)
 		require.NoError(t, err)
 
 		assert.IsType(t, &clientSecretTokenRetriever{}, result)
@@ -53,7 +57,7 @@ func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
 		credentials.AzureCloud = azsettings.AzureChina
 		credentials.Authority = "https://another.com/"
 
-		result, err := getClientSecretTokenRetriever(credentials)
+		result, err := getClientSecretTokenRetriever(settings, credentials)
 		require.NoError(t, err)
 
 		assert.IsType(t, &clientSecretTokenRetriever{}, result)
@@ -66,7 +70,7 @@ func TestAzureTokenProvider_getClientSecretCredential(t *testing.T) {
 		credentials := defaultCredentials()
 		credentials.AzureCloud = "InvalidCloud"
 
-		_, err := getClientSecretTokenRetriever(credentials)
+		_, err := getClientSecretTokenRetriever(settings, credentials)
 		require.Error(t, err)
 	})
 }

--- a/aztokenprovider/token_provider.go
+++ b/aztokenprovider/token_provider.go
@@ -54,7 +54,7 @@ func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials
 			tokenRetriever: tokenRetriever,
 		}, nil
 	case *azcredentials.AzureClientSecretCredentials:
-		tokenRetriever, err := getClientSecretTokenRetriever(c)
+		tokenRetriever, err := getClientSecretTokenRetriever(settings, c)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Replaces hardcoded clouds in Azure token provider by cloud configuration from `azsettings.AzureCloudSettings`.

This is internal refactoring to make Azure token provider more flexible in supporting different clouds but there's no change in behavior for the code which consumes the SDK.