### PR TITLE
Expose AzureAuthEnabled (azure_auth_enabled) value in settings

### DIFF
--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -9,6 +9,8 @@ import (
 const (
 	AzureCloud = "GFAZPL_AZURE_CLOUD"
 
+	AzureAuthEnabled = "GFAZPL_AZURE_AUTH_ENABLED"
+
 	ManagedIdentityEnabled  = "GFAZPL_MANAGED_IDENTITY_ENABLED"
 	ManagedIdentityClientID = "GFAZPL_MANAGED_IDENTITY_CLIENT_ID"
 
@@ -33,6 +35,14 @@ func ReadFromEnv() (*AzureSettings, error) {
 	azureSettings := &AzureSettings{}
 
 	azureSettings.Cloud = envutil.GetOrFallback(AzureCloud, fallbackAzureCloud, AzurePublic)
+
+	// Azure auth enabled or not
+	if azureAuthEnabled, err := envutil.GetBoolOrDefault(AzureAuthEnabled, false); err != nil {
+		err = fmt.Errorf("invalid Azure configuration: %w", err)
+		return nil, err
+	} else if azureAuthEnabled {
+		azureSettings.AzureAuthEnabled = true
+	}
 
 	// Managed Identity authentication
 	if msiEnabled, err := envutil.GetBoolOrFallback(ManagedIdentityEnabled, fallbackManagedIdentityEnabled, false); err != nil {
@@ -97,6 +107,10 @@ func WriteToEnvStr(azureSettings *AzureSettings) []string {
 	if azureSettings != nil {
 		if azureSettings.Cloud != "" {
 			envs = append(envs, fmt.Sprintf("%s=%s", AzureCloud, azureSettings.Cloud))
+		}
+
+		if azureSettings.AzureAuthEnabled {
+			envs = append(envs, fmt.Sprintf("%s=true", AzureAuthEnabled))
 		}
 
 		if azureSettings.ManagedIdentityEnabled {

--- a/azsettings/env_test.go
+++ b/azsettings/env_test.go
@@ -20,6 +20,17 @@ func TestReadFromEnv(t *testing.T) {
 		assert.Equal(t, "TestCloud", azureSettings.Cloud)
 	})
 
+	t.Run("should set azureAuthEnabled if variable is set", func(t *testing.T) {
+		unset, err := setEnvVar("GFAZPL_AZURE_AUTH_ENABLED", "true")
+		require.NoError(t, err)
+		defer unset()
+
+		azureSettings, err := ReadFromEnv()
+		require.NoError(t, err)
+
+		assert.Equal(t, true, azureSettings.AzureAuthEnabled)
+	})
+
 	t.Run("should set cloud if fallback variable is set", func(t *testing.T) {
 		unset1, err := setEnvVar("GFAZPL_AZURE_CLOUD", "")
 		require.NoError(t, err)
@@ -362,6 +373,17 @@ func TestWriteToEnvStr(t *testing.T) {
 
 		require.Len(t, envs, 1)
 		assert.Equal(t, "GFAZPL_AZURE_CLOUD=AzureCloud", envs[0])
+	})
+
+	t.Run("should return azureAuthEnabled if set", func(t *testing.T) {
+		azureSettings := &AzureSettings{
+			AzureAuthEnabled: true,
+		}
+
+		envs := WriteToEnvStr(azureSettings)
+
+		require.Len(t, envs, 1)
+		assert.Equal(t, "GFAZPL_AZURE_AUTH_ENABLED=true", envs[0])
 	})
 
 	t.Run("should return managed identity set if enabled", func(t *testing.T) {

--- a/azsettings/settings.go
+++ b/azsettings/settings.go
@@ -8,6 +8,7 @@ import (
 )
 
 type AzureSettings struct {
+	AzureAuthEnabled        bool
 	Cloud                   string
 	ManagedIdentityEnabled  bool
 	ManagedIdentityClientId string
@@ -52,6 +53,10 @@ func ReadFromContext(ctx context.Context) (*AzureSettings, bool) {
 
 	if cfg == nil {
 		return settings, false
+	}
+
+	if v := cfg.Get(AzureAuthEnabled); v == strconv.FormatBool(true) {
+		settings.AzureAuthEnabled = true
 	}
 
 	hasSettings := false

--- a/azsettings/settings_test.go
+++ b/azsettings/settings_test.go
@@ -44,6 +44,7 @@ func TestSettingsFromContext(t *testing.T) {
 				name: "azure settings in config",
 				cfg: backend.NewGrafanaCfg(map[string]string{
 					AzureCloud:                AzurePublic,
+					AzureAuthEnabled:          "true",
 					ManagedIdentityEnabled:    "true",
 					ManagedIdentityClientID:   "mock_managed_identity_client_id",
 					UserIdentityEnabled:       "true",
@@ -58,6 +59,7 @@ func TestSettingsFromContext(t *testing.T) {
 				}),
 				expectedAzure: &AzureSettings{
 					Cloud:                   AzurePublic,
+					AzureAuthEnabled:        true,
 					ManagedIdentityEnabled:  true,
 					ManagedIdentityClientId: "mock_managed_identity_client_id",
 					UserIdentityEnabled:     true,


### PR DESCRIPTION
This is required as part of Prometheus decoupling/externalisation. We rely on this value in https://github.com/grafana/grafana/blob/6dea3102cb04ddde8e3a4e269a2d80023593150e/pkg/tsdb/prometheus/client/transport.go#L41

In order to read the value it must be exposed. 

After merging and having a new release, I will add that key `GFAZPL_AZURE_AUTH_ENABLED` to grafana/grafana in https://github.com/grafana/grafana/blob/536153c3362782ae7f79e06755e8c7e0cd3b3acd/pkg/plugins/envvars/envvars.go#L154