### PR TITLE
Get explicitly configured Azure clouds

### DIFF
--- a/azsettings/cloud_settings.go
+++ b/azsettings/cloud_settings.go
@@ -1,8 +1,6 @@
 package azsettings
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type AzureCloudInfo struct {
 	Name        string
@@ -55,20 +53,6 @@ var predefinedClouds = []*AzureCloudSettings{
 	},
 }
 
-func (*AzureSettings) Clouds() []AzureCloudInfo {
-	clouds := getClouds()
-
-	results := make([]AzureCloudInfo, 0, len(clouds))
-	for _, cloud := range clouds {
-		results = append(results, AzureCloudInfo{
-			Name:        cloud.Name,
-			DisplayName: cloud.DisplayName,
-		})
-	}
-
-	return results
-}
-
 func (*AzureSettings) GetCloud(cloudName string) (*AzureCloudSettings, error) {
 	clouds := getClouds()
 
@@ -81,6 +65,36 @@ func (*AzureSettings) GetCloud(cloudName string) (*AzureCloudSettings, error) {
 	return nil, fmt.Errorf("the Azure cloud '%s' not supported", cloudName)
 }
 
+func (*AzureSettings) Clouds() []AzureCloudInfo {
+	clouds := getClouds()
+	return mapCloudInfo(clouds)
+}
+
+func (*AzureSettings) ConfiguredClouds() []AzureCloudInfo {
+	clouds := getConfiguredClouds()
+	return mapCloudInfo(clouds)
+}
+
+func mapCloudInfo(clouds []*AzureCloudSettings) []AzureCloudInfo {
+	results := make([]AzureCloudInfo, 0, len(clouds))
+	for _, cloud := range clouds {
+		results = append(results, AzureCloudInfo{
+			Name:        cloud.Name,
+			DisplayName: cloud.DisplayName,
+		})
+	}
+	return results
+}
+
 func getClouds() []*AzureCloudSettings {
+	if clouds := getConfiguredClouds(); len(clouds) > 0 {
+		return clouds
+	}
+
 	return predefinedClouds
+}
+
+func getConfiguredClouds() []*AzureCloudSettings {
+	// Configuration of Azure clouds not yet supported
+	return nil
 }

--- a/azsettings/cloud_settings_test.go
+++ b/azsettings/cloud_settings_test.go
@@ -18,6 +18,15 @@ func TestGetClouds(t *testing.T) {
 	assert.Equal(t, clouds[2].Name, "AzureUSGovernment")
 }
 
+func TestGetConfiguredClouds(t *testing.T) {
+	settings := &AzureSettings{}
+
+	clouds := settings.ConfiguredClouds()
+
+	// Configuration of Azure clouds not yet supported
+	assert.Len(t, clouds, 0)
+}
+
 func TestGetCloud(t *testing.T) {
 	settings := &AzureSettings{}
 


### PR DESCRIPTION
Extends `azsettings.AzureSettings` with additional method `ConfiguredClouds()`:

```go
clouds := azureSettings.ConfiguredClouds()
```

This method returns a list of clouds only if they were customized via configuration.

Orignal method `Clouds()` returns a list of clouds regardless whether they are predefined or configured:
```go
clouds := azureSettings.Clouds()
```
