### PR TITLE
Update cache to renew retriever if token is expired

### DIFF
--- a/aztokenprovider/retriever_clientsecret.go
+++ b/aztokenprovider/retriever_clientsecret.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -69,6 +70,11 @@ func (c *clientSecretTokenRetriever) GetAccessToken(ctx context.Context, scopes 
 	}
 
 	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+// Empty implementation
+func (c *clientSecretTokenRetriever) GetExpiry() *time.Time {
+	return nil
 }
 
 func hashSecret(secret string) string {

--- a/aztokenprovider/retriever_msi.go
+++ b/aztokenprovider/retriever_msi.go
@@ -3,6 +3,7 @@ package aztokenprovider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -57,4 +58,9 @@ func (c *managedIdentityTokenRetriever) GetAccessToken(ctx context.Context, scop
 	}
 
 	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+// Empty implementation
+func (c *managedIdentityTokenRetriever) GetExpiry() *time.Time {
+	return nil
 }

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -45,7 +45,7 @@ func (c *onBehalfOfTokenRetriever) GetExpiry() *time.Time {
 		}
 
 		expiry, err := claims.GetExpirationTime()
-		if err != nil {
+		if err != nil || expiry == nil {
 			// Unable to get expiration from existing token so store the new one in cache
 			return &time.Time{}
 		}

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -32,8 +32,6 @@ func (r *onBehalfOfTokenRetriever) GetAccessToken(ctx context.Context, scopes []
 	return accessToken, nil
 }
 
-func (c *onBehalfOfTokenRetriever) HasExpired() bool { return true }
-
 // Returns the expiry time from the ID token or the 0 time value (which will always be expired)
 func (c *onBehalfOfTokenRetriever) GetExpiry() *time.Time {
 	if c != nil && c.idToken != "" {

--- a/aztokenprovider/retriever_obo.go
+++ b/aztokenprovider/retriever_obo.go
@@ -3,6 +3,9 @@ package aztokenprovider
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type onBehalfOfTokenRetriever struct {
@@ -27,4 +30,28 @@ func (r *onBehalfOfTokenRetriever) GetAccessToken(ctx context.Context, scopes []
 	}
 
 	return accessToken, nil
+}
+
+func (c *onBehalfOfTokenRetriever) HasExpired() bool { return true }
+
+// Returns the expiry time from the ID token or the 0 time value (which will always be expired)
+func (c *onBehalfOfTokenRetriever) GetExpiry() *time.Time {
+	if c != nil && c.idToken != "" {
+		claims := jwt.MapClaims{}
+		_, _, err := jwt.NewParser(jwt.WithValidMethods([]string{"ES256"})).ParseUnverified(c.idToken, claims)
+		if err != nil {
+			// Existing token is invalid in some way so store the new one in cache
+			return &time.Time{}
+		}
+
+		expiry, err := claims.GetExpirationTime()
+		if err != nil {
+			// Unable to get expiration from existing token so store the new one in cache
+			return &time.Time{}
+		}
+
+		return &expiry.Time
+	}
+
+	return &time.Time{}
 }

--- a/aztokenprovider/retriever_obo_test.go
+++ b/aztokenprovider/retriever_obo_test.go
@@ -1,0 +1,79 @@
+package aztokenprovider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OBORetrieverGetExpiry(t *testing.T) {
+	t.Run("returns 0 time value if retriever is nil", func(t *testing.T) {
+		retriever := onBehalfOfTokenRetriever{}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &time.Time{})
+	})
+	t.Run("returns 0 time value if idToken is empty", func(t *testing.T) {
+		retriever := onBehalfOfTokenRetriever{idToken: ""}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &time.Time{})
+	})
+	t.Run("returns 0 time value if it is not possible to parse JWT", func(t *testing.T) {
+		retriever := onBehalfOfTokenRetriever{idToken: "fake-string"}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &time.Time{})
+	})
+	t.Run("returns 0 time value if there is no expiration time", func(t *testing.T) {
+		var secretKey = []byte("secret-key")
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256,
+			jwt.MapClaims{
+				"test-claim": "test",
+			})
+		tokenString, err := token.SignedString(secretKey)
+		if err != nil {
+			t.Error(err)
+		}
+		retriever := onBehalfOfTokenRetriever{idToken: tokenString}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &time.Time{})
+	})
+	t.Run("returns 0 time value if expiration time is invalid", func(t *testing.T) {
+		var secretKey = []byte("secret-key")
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256,
+			jwt.MapClaims{
+				"test-claim": "test",
+				"exp":        "string not valid",
+			})
+		tokenString, err := token.SignedString(secretKey)
+		if err != nil {
+			t.Error(err)
+		}
+		retriever := onBehalfOfTokenRetriever{idToken: tokenString}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &time.Time{})
+	})
+	t.Run("returns time value if expiration time is valid", func(t *testing.T) {
+		// Truncate to match the library
+		expiryTime := time.Now().Truncate(time.Second)
+		var secretKey = []byte("secret-key")
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256,
+			jwt.MapClaims{
+				"test-claim": "test",
+				"exp":        expiryTime.Unix(),
+			})
+		tokenString, err := token.SignedString(secretKey)
+		if err != nil {
+			t.Error(err)
+		}
+		retriever := onBehalfOfTokenRetriever{idToken: tokenString}
+		expiry := retriever.GetExpiry()
+
+		require.Equal(t, expiry, &expiryTime)
+	})
+}

--- a/aztokenprovider/retriever_username.go
+++ b/aztokenprovider/retriever_username.go
@@ -3,6 +3,7 @@ package aztokenprovider
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type usernameTokenRetriever struct {
@@ -26,4 +27,9 @@ func (r *usernameTokenRetriever) GetAccessToken(ctx context.Context, scopes []st
 	}
 
 	return accessToken, nil
+}
+
+// Empty implementation
+func (c *usernameTokenRetriever) GetExpiry() *time.Time {
+	return nil
 }

--- a/aztokenprovider/retriever_workloadidentity.go
+++ b/aztokenprovider/retriever_workloadidentity.go
@@ -3,6 +3,7 @@ package aztokenprovider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -77,4 +78,9 @@ func (c *workloadIdentityTokenRetriever) GetAccessToken(ctx context.Context, sco
 	}
 
 	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+// Empty implementation
+func (c *workloadIdentityTokenRetriever) GetExpiry() *time.Time {
+	return nil
 }

--- a/aztokenprovider/token_cache.go
+++ b/aztokenprovider/token_cache.go
@@ -82,9 +82,10 @@ func (c *tokenCacheImpl) getEntryFor(ctx context.Context, credential TokenRetrie
 	expiry := entry.(*credentialCacheEntry).retriever.GetExpiry()
 	// Store new cache value if the current one has expired (only applies to OBO retriever)
 	if expiry != nil && !expiry.After(time.Now()) {
-		entry, _ = c.cache.LoadOrStore(key, &credentialCacheEntry{
+		c.cache.Store(key, &credentialCacheEntry{
 			retriever: credential,
 		})
+		entry, _ = c.cache.Load(key)
 	}
 
 	return entry.(*credentialCacheEntry)

--- a/aztokenprovider/token_cache.go
+++ b/aztokenprovider/token_cache.go
@@ -27,6 +27,7 @@ type TokenRetriever interface {
 	GetCacheKey(grafanaMultiTenantId string) string
 	Init() error
 	GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error)
+	GetExpiry() *time.Time
 }
 
 type ConcurrentTokenCache interface {
@@ -42,6 +43,7 @@ type tokenCacheImpl struct {
 }
 type credentialCacheEntry struct {
 	retriever TokenRetriever
+	expiry    *time.Time
 
 	credInit  uint32
 	credMutex sync.Mutex
@@ -67,7 +69,19 @@ func (c *tokenCacheImpl) getEntryFor(ctx context.Context, credential TokenRetrie
 	tid := returnGrafanaMultiTenantId(ctx)
 
 	key := credential.GetCacheKey(tid)
-	if entry, ok = c.cache.Load(key); !ok {
+
+	entry, ok = c.cache.Load(key)
+	// Store new cache value if there isn't an existing one
+	if !ok {
+		entry, _ = c.cache.LoadOrStore(key, &credentialCacheEntry{
+			retriever: credential,
+		})
+		return entry.(*credentialCacheEntry)
+	}
+
+	expiry := entry.(*credentialCacheEntry).retriever.GetExpiry()
+	// Store new cache value if the current one has expired (only applies to OBO retriever)
+	if expiry != nil && !expiry.After(time.Now()) {
 		entry, _ = c.cache.LoadOrStore(key, &credentialCacheEntry{
 			retriever: credential,
 		})

--- a/aztokenprovider/token_cache_test.go
+++ b/aztokenprovider/token_cache_test.go
@@ -46,6 +46,10 @@ func (c *fakeRetriever) GetAccessToken(ctx context.Context, scopes []string) (*A
 	return fakeAccessToken, nil
 }
 
+func (c *fakeRetriever) GetExpiry() *time.Time {
+	return nil
+}
+
 func TestConcurrentTokenCache_GetAccessToken(t *testing.T) {
 	ctx := context.Background()
 

--- a/aztokenprovider/token_cache_test.go
+++ b/aztokenprovider/token_cache_test.go
@@ -484,7 +484,7 @@ func TestTokenExpiry_GetAccessToken(t *testing.T) {
 		require.Equal(t, tokenRetriever.expiryCalledTimes, 0)
 	})
 
-	t.Run("will check expiry if credential cached and will store if expiry is nil", func(t *testing.T) {
+	t.Run("will check expiry if credential cached and will not store if expiry is nil", func(t *testing.T) {
 		credential := &fakeRetriever{key: "credential-1"}
 		cache := NewConcurrentTokenCache()
 		token1, err := cache.GetAccessToken(ctx, credential, scopes)

--- a/aztokenprovider/token_cache_test.go
+++ b/aztokenprovider/token_cache_test.go
@@ -16,8 +16,10 @@ type fakeRetriever struct {
 	key                string
 	initCalledTimes    int
 	calledTimes        int
+	expiryCalledTimes  int
 	initFunc           func() error
 	getAccessTokenFunc func(ctx context.Context, scopes []string) (*AccessToken, error)
+	getExpiryFunc      func() *time.Time
 }
 
 func (c *fakeRetriever) GetCacheKey(grafanaMultiTenantId string) string {
@@ -27,6 +29,7 @@ func (c *fakeRetriever) GetCacheKey(grafanaMultiTenantId string) string {
 func (c *fakeRetriever) Reset() {
 	c.initCalledTimes = 0
 	c.calledTimes = 0
+	c.expiryCalledTimes = 0
 }
 
 func (c *fakeRetriever) Init() error {
@@ -47,6 +50,11 @@ func (c *fakeRetriever) GetAccessToken(ctx context.Context, scopes []string) (*A
 }
 
 func (c *fakeRetriever) GetExpiry() *time.Time {
+	c.expiryCalledTimes = c.expiryCalledTimes + 1
+	if c.getExpiryFunc != nil {
+		return c.getExpiryFunc()
+	}
+
 	return nil
 }
 
@@ -458,4 +466,84 @@ func TestScopesCacheEntry_GetAccessToken(t *testing.T) {
 			assert.Equal(t, 2, tokenRetriever.calledTimes)
 		})
 	})
+}
+
+func TestTokenExpiry_GetAccessToken(t *testing.T) {
+	ctx := context.Background()
+	scopes := []string{"test-scope"}
+
+	t.Run("will not check expiry if no credential cached", func(t *testing.T) {
+		tokenRetriever := &fakeRetriever{
+			key: "credential",
+		}
+
+		cache := NewConcurrentTokenCache()
+		_, err := cache.GetAccessToken(ctx, tokenRetriever, scopes)
+
+		require.Nil(t, err)
+		require.Equal(t, tokenRetriever.expiryCalledTimes, 0)
+	})
+
+	t.Run("will check expiry if credential cached and will store if expiry is nil", func(t *testing.T) {
+		credential := &fakeRetriever{key: "credential-1"}
+		cache := NewConcurrentTokenCache()
+		token1, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+
+		token2, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+		assert.Equal(t, "credential-1-token-1", token1)
+		require.Equal(t, token1, token2)
+		require.Equal(t, credential.expiryCalledTimes, 1)
+	})
+
+	t.Run("will check expiry if credential cached and will store if expiry is not nil (default return)", func(t *testing.T) {
+		credential := &fakeRetriever{key: "credential-1", getExpiryFunc: func() *time.Time {
+			return &time.Time{}
+		}}
+		cache := NewConcurrentTokenCache()
+		token1, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+
+		token2, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+		assert.Equal(t, "credential-1-token-1", token1)
+		require.NotEqual(t, token1, token2)
+		assert.Equal(t, "credential-1-token-2", token2)
+		require.Equal(t, credential.expiryCalledTimes, 1)
+	})
+
+	t.Run("will check expiry if credential cached and will not store if expiry is after now ", func(t *testing.T) {
+		credential := &fakeRetriever{key: "credential-1", getExpiryFunc: func() *time.Time {
+			expiry := time.Now().Add(1 * time.Hour)
+			return &expiry
+		}}
+		cache := NewConcurrentTokenCache()
+		token1, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+
+		token2, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+		assert.Equal(t, "credential-1-token-1", token1)
+		require.Equal(t, token1, token2)
+		require.Equal(t, credential.expiryCalledTimes, 1)
+	})
+
+	t.Run("will check expiry if credential cached and will store if expiry is before now ", func(t *testing.T) {
+		credential := &fakeRetriever{key: "credential-1", getExpiryFunc: func() *time.Time {
+			expiry := time.Now().Add(-20 * time.Minute)
+			return &expiry
+		}}
+		cache := NewConcurrentTokenCache()
+		token1, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+
+		token2, err := cache.GetAccessToken(ctx, credential, scopes)
+		require.Nil(t, err)
+		assert.Equal(t, "credential-1-token-1", token1)
+		require.NotEqual(t, token1, token2)
+		assert.Equal(t, "credential-1-token-2", token2)
+		require.Equal(t, credential.expiryCalledTimes, 1)
+	})
+
 }


### PR DESCRIPTION
A bug in the cache didn't check the expiry times of ID tokens for the OBO retriever. This meant that even when the token was expired and a new one available, the new token would not be used as the old one was present in the cache.