### PR TITLE
Add functionality to support retrieving custom clouds

### DIFF
--- a/azsettings/cloud_settings.go
+++ b/azsettings/cloud_settings.go
@@ -55,9 +55,31 @@ var predefinedClouds = []*AzureCloudSettings{
 	},
 }
 
-func (*AzureSettings) Clouds() []AzureCloudInfo {
+func (*AzureSettings) GetCloud(cloudName string) (*AzureCloudSettings, error) {
 	clouds := getClouds()
 
+	for _, cloud := range clouds {
+		if cloud.Name == cloudName {
+			return cloud, nil
+		}
+	}
+
+	return nil, fmt.Errorf("the Azure cloud '%s' is not supported", cloudName)
+}
+
+// Returns all clouds configured on the instance, including custom clouds if any
+func (*AzureSettings) Clouds() []AzureCloudInfo {
+	clouds := getClouds()
+	return mapCloudInfo(clouds)
+}
+
+// Returns only the custom clouds configured on the instance
+func (*AzureSettings) CustomClouds() []AzureCloudInfo {
+	clouds := getCustomClouds()
+	return mapCloudInfo(clouds)
+}
+
+func mapCloudInfo(clouds []*AzureCloudSettings) []AzureCloudInfo {
 	results := make([]AzureCloudInfo, 0, len(clouds))
 	for _, cloud := range clouds {
 		results = append(results, AzureCloudInfo{
@@ -69,18 +91,16 @@ func (*AzureSettings) Clouds() []AzureCloudInfo {
 	return results
 }
 
-func (*AzureSettings) GetCloud(cloudName string) (*AzureCloudSettings, error) {
-	clouds := getClouds()
-
-	for _, cloud := range clouds {
-		if cloud.Name == cloudName {
-			return cloud, nil
-		}
+func getClouds() []*AzureCloudSettings {
+	if clouds := getCustomClouds(); len(clouds) > 0 {
+		allClouds := append(clouds, predefinedClouds...)
+		return allClouds
 	}
 
-	return nil, fmt.Errorf("the Azure cloud '%s' not supported", cloudName)
+	return predefinedClouds
 }
 
-func getClouds() []*AzureCloudSettings {
-	return predefinedClouds
+func getCustomClouds() []*AzureCloudSettings {
+	// Configuration of Azure clouds not yet supported
+	return nil
 }

--- a/azsettings/cloud_settings_test.go
+++ b/azsettings/cloud_settings_test.go
@@ -18,6 +18,15 @@ func TestGetClouds(t *testing.T) {
 	assert.Equal(t, clouds[2].Name, "AzureUSGovernment")
 }
 
+func TestGetCustomClouds(t *testing.T) {
+	settings := &AzureSettings{}
+
+	clouds := settings.CustomClouds()
+
+	// Configuration of Azure clouds not yet supported
+	assert.Len(t, clouds, 0)
+}
+
 func TestGetCloud(t *testing.T) {
 	settings := &AzureSettings{}
 


### PR DESCRIPTION
Extends `azsettings.AzureSettings` with additional method `CustomClouds()`:

```go
clouds := azureSettings.CustomClouds()
```

This method returns a list of clouds if they were added via configuration.

Orignal method `Clouds()` returns a list of clouds regardless of they are predefined or configured:
```go
clouds := azureSettings.Clouds()
```

Updated version of #104 
