### PR TITLE
Add error checking to prevent panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## v2.0.1
-
-- Added error checks to prevent panics with session users.
-
 ## v2.0.0
 
 - **Breaking change:** `mapUtil` is removed [#106](https://github.com/grafana/grafana-azure-sdk-go/pull/106). `mapUtil` functions moved to 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.0.1
+
+- Added error checks to prevent panics with session users.
+
 ## v2.0.0
 
 - **Breaking change:** `mapUtil` is removed [#106](https://github.com/grafana/grafana-azure-sdk-go/pull/106). `mapUtil` functions moved to 

--- a/azhttpclient/session_provider_test.go
+++ b/azhttpclient/session_provider_test.go
@@ -1,0 +1,45 @@
+package azhttpclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionProvider(t *testing.T) {
+	t.Run("should return a sessionId", func(t *testing.T) {
+		sessionProvider, err := newSessionProvider()
+		require.NoError(t, err)
+		usrctx := azusercontext.WithCurrentUser(context.Background(), azusercontext.CurrentUserContext{
+			User: &backend.User{
+				Login: "user1@example.org",
+			},
+			IdToken: "FAKE_ID_TOKEN",
+		})
+		sessionId, err := sessionProvider.GetSessionId(usrctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, sessionId)
+	})
+
+	t.Run("should error if no user is in context", func(t *testing.T) {
+		sessionProvider, err := newSessionProvider()
+		require.NoError(t, err)
+		sessionId, err := sessionProvider.GetSessionId(context.Background())
+		require.Error(t, err)
+		require.Empty(t, sessionId)
+	})
+
+	t.Run("should error if no user.User is in context", func(t *testing.T) {
+		sessionProvider, err := newSessionProvider()
+		require.NoError(t, err)
+		usrctx := azusercontext.WithCurrentUser(context.Background(), azusercontext.CurrentUserContext{
+			IdToken: "FAKE_ID_TOKEN",
+		})
+		sessionId, err := sessionProvider.GetSessionId(usrctx)
+		require.Error(t, err)
+		require.Empty(t, sessionId)
+	})
+}

--- a/aztokenprovider/retriever_clientsecret.go
+++ b/aztokenprovider/retriever_clientsecret.go
@@ -79,6 +79,9 @@ func (c *clientSecretTokenRetriever) GetExpiry() *time.Time {
 
 func hashSecret(secret string) string {
 	hash := sha256.New()
-	_, _ = hash.Write([]byte(secret))
+	_, err := hash.Write([]byte(secret))
+	if err != nil {
+		return ""
+	}
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }

--- a/aztokenprovider/token_client.go
+++ b/aztokenprovider/token_client.go
@@ -186,10 +186,16 @@ func requestUrlForm(ctx context.Context, httpClient *http.Client, requestUrl str
 		}
 
 		var errorMessage strings.Builder
-		_, _ = fmt.Fprintf(&errorMessage, "request failed with status %s", resp.Status)
+		_, err = fmt.Fprintf(&errorMessage, "request failed with status %s", resp.Status)
+		if err != nil {
+			return err
+		}
 
 		if bodyString != "" {
-			_, _ = fmt.Fprintf(&errorMessage, ", body %s", bodyString)
+			_, err = fmt.Fprintf(&errorMessage, ", body %s", bodyString)
+			if err != nil {
+				return err
+			}
 		}
 
 		return errors.New(errorMessage.String())


### PR DESCRIPTION
This should fix incident-2024-05-07-panic-in-azure-monitor-datasource

I added tests for the session provider. It would be nice if these tests were in a separate namespace, but that would require too much refactoring for now

I checked other spots were we were not checking errors, but I don't think these will ever fail.

