### PR TITLE
Remove user identity validation from ReadFromEnv

### DIFF
--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -81,18 +81,8 @@ func ReadFromEnv() (*AzureSettings, error) {
 		err = fmt.Errorf("invalid Azure configuration: %w", err)
 		return nil, err
 	} else if userIdentityEnabled {
-		tokenUrl, err := envutil.Get(UserIdentityTokenURL)
-		if err != nil {
-			err = fmt.Errorf("token URL must be set when user identity authentication enabled: %w", err)
-			return nil, err
-		}
-
-		clientId, err := envutil.Get(UserIdentityClientID)
-		if err != nil {
-			err = fmt.Errorf("client ID must be set when user identity authentication enabled: %w", err)
-			return nil, err
-		}
-
+		tokenUrl, err := envutil.GetOrDefault(UserIdentityTokenURL, "")
+		clientId, err := envutil.GetOrDefault(UserIdentityClientID, "")
 		clientSecret := envutil.GetOrDefault(UserIdentityClientSecret, "")
 
 		assertion := envutil.GetOrDefault(UserIdentityAssertion, "")

--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -81,8 +81,8 @@ func ReadFromEnv() (*AzureSettings, error) {
 		err = fmt.Errorf("invalid Azure configuration: %w", err)
 		return nil, err
 	} else if userIdentityEnabled {
-		tokenUrl, err := envutil.GetOrDefault(UserIdentityTokenURL, "")
-		clientId, err := envutil.GetOrDefault(UserIdentityClientID, "")
+		tokenUrl := envutil.GetOrDefault(UserIdentityTokenURL, "")
+		clientId := envutil.GetOrDefault(UserIdentityClientID, "")
 		clientSecret := envutil.GetOrDefault(UserIdentityClientSecret, "")
 
 		assertion := envutil.GetOrDefault(UserIdentityAssertion, "")


### PR DESCRIPTION
external data sources depends on `ReadFromEnv`.

If and admin has enabled `user identity`, but didn't define a token_url, it would result into an error. It does matter if the data source supports `user identity` or not.

Bulit-in datasources doesn't have that issue, since they use ReadFromContext and doesn't have that restrictions.

https://github.com/grafana/grafana-azure-sdk-go/blob/c271284be0be9f85c64b6d2c8d00d22e458dc80f/azsettings/settings.go#L95-L109