### PR TITLE
Adding New Azure OAuth flags for User Identity Support

### DIFF
--- a/azsettings/env.go
+++ b/azsettings/env.go
@@ -20,12 +20,15 @@ const (
 	WorkloadIdentityClientID  = "GFAZPL_WORKLOAD_IDENTITY_CLIENT_ID"
 	WorkloadIdentityTokenFile = "GFAZPL_WORKLOAD_IDENTITY_TOKEN_FILE"
 
-	UserIdentityEnabled                    = "GFAZPL_USER_IDENTITY_ENABLED"
-	UserIdentityTokenURL                   = "GFAZPL_USER_IDENTITY_TOKEN_URL"
-	UserIdentityClientID                   = "GFAZPL_USER_IDENTITY_CLIENT_ID"
-	UserIdentityClientSecret               = "GFAZPL_USER_IDENTITY_CLIENT_SECRET"
-	UserIdentityAssertion                  = "GFAZPL_USER_IDENTITY_ASSERTION"
-	UserIdentityFallbackCredentialsEnabled = "GFAZPL_USER_IDENTITY_FALLBACK_SERVICE_CREDENTIALS_ENABLED"
+	UserIdentityEnabled                     = "GFAZPL_USER_IDENTITY_ENABLED"
+	UserIdentityTokenURL                    = "GFAZPL_USER_IDENTITY_TOKEN_URL"
+	UserIdentityClientAuthentication        = "GFAZPL_USER_IDENTITY_CLIENT_AUTHENTICATION"
+	UserIdentityClientID                    = "GFAZPL_USER_IDENTITY_CLIENT_ID"
+	UserIdentityClientSecret                = "GFAZPL_USER_IDENTITY_CLIENT_SECRET"
+	UserIdentityManagedIdentityClientID     = "GFAZPL_USER_IDENTITY_MANAGED_IDENTITY_CLIENT_ID"
+	UserIdentityFederatedCredentialAudience = "GFAZPL_USER_IDENTITY_FEDERATED_CREDENTIAL_AUDIENCE"
+	UserIdentityAssertion                   = "GFAZPL_USER_IDENTITY_ASSERTION"
+	UserIdentityFallbackCredentialsEnabled  = "GFAZPL_USER_IDENTITY_FALLBACK_SERVICE_CREDENTIALS_ENABLED"
 
 	AzureEntraPasswordCredentialsEnabled = "GFAZPL_AZURE_ENTRA_PASSWORD_CREDENTIALS_ENABLED"
 

--- a/azsettings/settings.go
+++ b/azsettings/settings.go
@@ -36,9 +36,12 @@ type WorkloadIdentitySettings struct {
 }
 
 type TokenEndpointSettings struct {
-	TokenUrl     string
-	ClientId     string
-	ClientSecret string
+	TokenUrl     				string
+	ClientAuthentication	 	string
+	ClientId     				string
+	ClientSecret 				string
+	ManagedIdentityClientId 	string
+	FederatedCredentialAudience string
 
 	// UsernameAssertion allows to use a custom token request assertion when Grafana is behind auth proxy
 	UsernameAssertion bool

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/grafana/grafana-azure-sdk-go/v2
 
-go 1.21
-toolchain go1.22.5
+go 1.22
+
+toolchain go1.23.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
Azure OAuth for Grafana is in the process of adding a few new flags as a part of a new feature implementation, specifically the use of federated credentials for logging into Azure AD. This PR can be found [here](https://github.com/grafana/grafana/pull/95455) for reference.

This PR adds these flags as supported values for the `TokenEndpointSettings` in preparation for full support of this new feature implementation for user identity authentication within the various plugins. This PR allows for Grafana to set these new flags inside the `pkg/setting/setting_azure.go` and `pkg/services/pluginsintegration/pluginconfig/request.go` files within the Grafana repository.