### PR TITLE
Add override properties for token endpoint settings

### DIFF
--- a/azsettings/settings.go
+++ b/azsettings/settings.go
@@ -45,6 +45,14 @@ type TokenEndpointSettings struct {
 
 	// UsernameAssertion allows to use a custom token request assertion when Grafana is behind auth proxy
 	UsernameAssertion bool
+
+	// Internal properties to track if values were overridden in the `azure` section
+	TokenUrlOverride                    bool
+	ClientAuthenticationOverride        bool
+	ClientIdOverride                    bool
+	ClientSecretOverride                bool
+	ManagedIdentityClientIdOverride     bool
+	FederatedCredentialAudienceOverride bool
 }
 
 func (settings *AzureSettings) GetDefaultCloud() string {


### PR DESCRIPTION
It's possible for a user to override some of the user-auth related configuration in the `azure` section of the config.

In the cases where this happens, it'd be useful for us to know that the properties have been overridden to ensure that the properties set in the plugin context are the correct ones.