### PR TITLE
feat: add federated identity credential support for cross-tenant authentication

### DIFF
--- a/azcredentials/builder.go
+++ b/azcredentials/builder.go
@@ -202,6 +202,32 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 			ClientId: clientId,
 		}
 		return credentials, nil
+
+	case AzureAuthFederatedIdentity:
+		sourceClientId, err := maputil.GetStringOptional(credentialsObj, "sourceClientId")
+		if err != nil {
+			return nil, err
+		}
+		targetTenantId, err := maputil.GetString(credentialsObj, "targetTenantId")
+		if err != nil {
+			return nil, err
+		}
+		targetClientId, err := maputil.GetString(credentialsObj, "targetClientId")
+		if err != nil {
+			return nil, err
+		}
+		federatedCredentialAudience, err := maputil.GetString(credentialsObj, "federatedCredentialAudience")
+		if err != nil {
+			return nil, err
+		}
+
+		credentials := &AzureFederatedIdentityCredentials{
+			SourceClientId:              sourceClientId,
+			TargetTenantId:              targetTenantId,
+			TargetClientId:              targetClientId,
+			FederatedCredentialAudience: federatedCredentialAudience,
+		}
+		return credentials, nil
 	default:
 		err := fmt.Errorf("the authentication type '%s' not supported", authType)
 		return nil, err

--- a/azcredentials/builder_test.go
+++ b/azcredentials/builder_test.go
@@ -494,4 +494,64 @@ func TestFromDatasourceData(t *testing.T) {
 		_, err := FromDatasourceData(data, secureData)
 		assert.Error(t, err)
 	})
+
+	t.Run("should return federated identity credentials when federated identity auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":                    "federatedidentity",
+				"sourceClientId":              "SOURCE-CLIENT-ID",
+				"targetTenantId":              "TARGET-TENANT-ID",
+				"targetClientId":              "TARGET-CLIENT-ID",
+				"federatedCredentialAudience": "api://AzureADTokenExchange",
+			},
+		}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureFederatedIdentityCredentials{}, result)
+		credential := result.(*AzureFederatedIdentityCredentials)
+
+		assert.Equal(t, "SOURCE-CLIENT-ID", credential.SourceClientId)
+		assert.Equal(t, "TARGET-TENANT-ID", credential.TargetTenantId)
+		assert.Equal(t, "TARGET-CLIENT-ID", credential.TargetClientId)
+		assert.Equal(t, "api://AzureADTokenExchange", credential.FederatedCredentialAudience)
+	})
+
+	t.Run("should return federated identity credentials when source client ID omitted", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":                    "federatedidentity",
+				"targetTenantId":              "TARGET-TENANT-ID",
+				"targetClientId":              "TARGET-CLIENT-ID",
+				"federatedCredentialAudience": "api://AzureADTokenExchange",
+			},
+		}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureFederatedIdentityCredentials{}, result)
+		credential := result.(*AzureFederatedIdentityCredentials)
+
+		assert.Equal(t, "", credential.SourceClientId)
+	})
+
+	t.Run("should return error for federated identity with missing target tenant ID", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType":                    "federatedidentity",
+				"targetClientId":              "TARGET-CLIENT-ID",
+				"federatedCredentialAudience": "api://AzureADTokenExchange",
+			},
+		}
+		var secureData = map[string]string{}
+
+		_, err := FromDatasourceData(data, secureData)
+		require.Error(t, err)
+	})
 }

--- a/azcredentials/cloud.go
+++ b/azcredentials/cloud.go
@@ -25,6 +25,9 @@ func GetAzureCloud(settings *azsettings.AzureSettings, credentials AzureCredenti
 		return c.ClientSecretCredentials.AzureCloud, nil
 	case *AzureEntraPasswordCredentials:
 		return settings.GetDefaultCloud(), nil
+	case *AzureFederatedIdentityCredentials:
+		// In case of federated identity, the cloud is always same as where Grafana is hosted
+		return settings.GetDefaultCloud(), nil
 	default:
 		err := fmt.Errorf("the Azure credentials of type '%s' not supported", c.AzureAuthType())
 		return "", err

--- a/azcredentials/credentials.go
+++ b/azcredentials/credentials.go
@@ -8,6 +8,7 @@ const (
 	AzureAuthClientCertificate        = "clientcertificate"
 	AzureAuthClientSecretObo          = "clientsecret-obo"
 	AzureAuthEntraPasswordCredentials = "ad-password"
+	AzureAuthFederatedIdentity        = "federatedidentity"
 )
 
 type AzureCredentials interface {
@@ -94,4 +95,17 @@ func (credentials *AzureClientSecretOboCredentials) AzureAuthType() string {
 
 func (credentials *AzureEntraPasswordCredentials) AzureAuthType() string {
 	return AzureAuthEntraPasswordCredentials
+}
+
+// AzureFederatedIdentityCredentials "Federated Identity" cross-tenant service identity credentials
+// using a managed identity assertion to obtain a token in a target tenant.
+type AzureFederatedIdentityCredentials struct {
+	SourceClientId              string
+	TargetTenantId              string
+	TargetClientId              string
+	FederatedCredentialAudience string
+}
+
+func (credentials *AzureFederatedIdentityCredentials) AzureAuthType() string {
+	return AzureAuthFederatedIdentity
 }

--- a/aztokenprovider/retriever_federatedidentity.go
+++ b/aztokenprovider/retriever_federatedidentity.go
@@ -1,0 +1,102 @@
+package aztokenprovider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
+)
+
+type federatedIdentityTokenRetriever struct {
+	sourceClientId              string
+	targetTenantId              string
+	targetClientId              string
+	federatedCredentialAudience string
+
+	credential azcore.TokenCredential
+}
+
+func getFederatedIdentityTokenRetriever(settings *azsettings.AzureSettings, credentials *azcredentials.AzureFederatedIdentityCredentials) (TokenRetriever, error) {
+	if credentials.TargetTenantId == "" {
+		return nil, fmt.Errorf("target tenant ID is required for federated identity authentication")
+	}
+	if credentials.TargetClientId == "" {
+		return nil, fmt.Errorf("target client ID is required for federated identity authentication")
+	}
+	if credentials.FederatedCredentialAudience == "" {
+		return nil, fmt.Errorf("federated credential audience is required for federated identity authentication")
+	}
+	if err := validateFederatedCredentialAudience(credentials.FederatedCredentialAudience); err != nil {
+		return nil, err
+	}
+
+	sourceClientId := credentials.SourceClientId
+	if sourceClientId == "" {
+		sourceClientId = settings.ManagedIdentityClientId
+	}
+
+	return &federatedIdentityTokenRetriever{
+		sourceClientId:              sourceClientId,
+		targetTenantId:              credentials.TargetTenantId,
+		targetClientId:              credentials.TargetClientId,
+		federatedCredentialAudience: credentials.FederatedCredentialAudience,
+	}, nil
+}
+
+func (c *federatedIdentityTokenRetriever) GetCacheKey(grafanaMultiTenantId string) string {
+	sourceClientId := c.sourceClientId
+	if sourceClientId == "" {
+		sourceClientId = "system"
+	}
+	return fmt.Sprintf("azure|fic|%s|%s|%s|%s|%s",
+		sourceClientId, c.targetTenantId, c.targetClientId,
+		c.federatedCredentialAudience, grafanaMultiTenantId)
+}
+
+func (c *federatedIdentityTokenRetriever) Init() error {
+	options := &azidentity.ManagedIdentityCredentialOptions{}
+	if c.sourceClientId != "" {
+		options.ID = azidentity.ClientID(c.sourceClientId)
+	}
+	sourceCredential, err := azidentity.NewManagedIdentityCredential(options)
+	if err != nil {
+		return fmt.Errorf("failed to create managed identity credential for federated identity: %w", err)
+	}
+
+	audience := c.federatedCredentialAudience
+	getAssertion := func(ctx context.Context) (string, error) {
+		tk, err := sourceCredential.GetToken(ctx, policy.TokenRequestOptions{
+			Scopes: []string{fmt.Sprintf("%s/.default", audience)},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get source identity token for federated identity exchange: %w", err)
+		}
+		return tk.Token, nil
+	}
+
+	credential, err := azidentity.NewClientAssertionCredential(c.targetTenantId, c.targetClientId, getAssertion, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create client assertion credential for federated identity: %w", err)
+	}
+
+	c.credential = credential
+	return nil
+}
+
+func (c *federatedIdentityTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	accessToken, err := c.credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: scopes})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+func (c *federatedIdentityTokenRetriever) GetExpiry() *time.Time {
+	return nil
+}

--- a/aztokenprovider/retriever_federatedidentity_test.go
+++ b/aztokenprovider/retriever_federatedidentity_test.go
@@ -1,0 +1,137 @@
+package aztokenprovider
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureTokenProvider_getFederatedIdentityTokenRetriever(t *testing.T) {
+	var settings = &azsettings.AzureSettings{
+		ManagedIdentityEnabled:  true,
+		ManagedIdentityClientId: "default-msi-client-id",
+	}
+
+	defaultCredentials := func() *azcredentials.AzureFederatedIdentityCredentials {
+		return &azcredentials.AzureFederatedIdentityCredentials{
+			SourceClientId:              "source-client-id",
+			TargetTenantId:              "d33b45df-af84-4d65-acde-1bd47e9d2ad9",
+			TargetClientId:              "ff326f8b-ff33-4844-9311-58cea4dfa073",
+			FederatedCredentialAudience: "api://AzureADTokenExchange",
+		}
+	}
+
+	t.Run("should return retriever", func(t *testing.T) {
+		credentials := defaultCredentials()
+
+		result, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+
+		assert.IsType(t, &federatedIdentityTokenRetriever{}, result)
+		retriever := result.(*federatedIdentityTokenRetriever)
+
+		assert.Equal(t, "source-client-id", retriever.sourceClientId)
+		assert.Equal(t, "d33b45df-af84-4d65-acde-1bd47e9d2ad9", retriever.targetTenantId)
+		assert.Equal(t, "ff326f8b-ff33-4844-9311-58cea4dfa073", retriever.targetClientId)
+		assert.Equal(t, "api://AzureADTokenExchange", retriever.federatedCredentialAudience)
+	})
+
+	t.Run("should use default MSI client ID from settings when not specified", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.SourceClientId = ""
+
+		result, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+
+		retriever := result.(*federatedIdentityTokenRetriever)
+		assert.Equal(t, "default-msi-client-id", retriever.sourceClientId)
+	})
+
+	t.Run("should fail when target tenant ID is missing", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.TargetTenantId = ""
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target tenant ID is required")
+	})
+
+	t.Run("should fail when target client ID is missing", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.TargetClientId = ""
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target client ID is required")
+	})
+
+	t.Run("should fail when federated credential audience is missing", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.FederatedCredentialAudience = ""
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "federated credential audience is required")
+	})
+
+	t.Run("should fail when federated credential audience is invalid", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.FederatedCredentialAudience = "api://InvalidAudience"
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("should produce correct cache key", func(t *testing.T) {
+		credentials := defaultCredentials()
+
+		result, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+
+		cacheKey := result.GetCacheKey("tenant-123")
+		assert.Equal(t, "azure|fic|source-client-id|d33b45df-af84-4d65-acde-1bd47e9d2ad9|ff326f8b-ff33-4844-9311-58cea4dfa073|api://AzureADTokenExchange|tenant-123", cacheKey)
+	})
+
+	t.Run("should use 'system' in cache key when source client ID is empty and no default", func(t *testing.T) {
+		settingsNoDefault := &azsettings.AzureSettings{
+			ManagedIdentityEnabled: true,
+		}
+		credentials := defaultCredentials()
+		credentials.SourceClientId = ""
+
+		result, err := getFederatedIdentityTokenRetriever(settingsNoDefault, credentials)
+		require.NoError(t, err)
+
+		cacheKey := result.GetCacheKey("")
+		assert.Contains(t, cacheKey, "|system|")
+	})
+
+	t.Run("should return nil from GetExpiry", func(t *testing.T) {
+		credentials := defaultCredentials()
+
+		result, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+
+		assert.Nil(t, result.GetExpiry())
+	})
+
+	t.Run("should accept US Gov audience", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.FederatedCredentialAudience = "api://AzureADTokenExchangeUSGov"
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+	})
+
+	t.Run("should accept China audience", func(t *testing.T) {
+		credentials := defaultCredentials()
+		credentials.FederatedCredentialAudience = "api://AzureADTokenExchangeChina"
+
+		_, err := getFederatedIdentityTokenRetriever(settings, credentials)
+		require.NoError(t, err)
+	})
+}

--- a/aztokenprovider/token_provider.go
+++ b/aztokenprovider/token_provider.go
@@ -73,6 +73,18 @@ func NewAzureAccessTokenProvider(settings *azsettings.AzureSettings, credentials
 			tokenCache:     azureTokenCache,
 			tokenRetriever: tokenRetriever,
 		}, nil
+	case *azcredentials.AzureFederatedIdentityCredentials:
+		if !settings.ManagedIdentityEnabled {
+			return nil, fmt.Errorf("managed identity authentication is not enabled in Grafana config (required as source identity for federated identity)")
+		}
+		tokenRetriever, err := getFederatedIdentityTokenRetriever(settings, c)
+		if err != nil {
+			return nil, err
+		}
+		return &serviceTokenProvider{
+			tokenCache:     azureTokenCache,
+			tokenRetriever: tokenRetriever,
+		}, nil
 	case *azcredentials.AadCurrentUserCredentials:
 		if !userIdentitySupported {
 			err = fmt.Errorf("user identity authentication is not supported by this datasource")


### PR DESCRIPTION
## Summary

Adds a new `federatedidentity` Azure credential type for secretless cross-tenant authentication. A managed identity in the local tenant obtains a token, which is then exchanged via `azidentity.NewClientAssertionCredential` for an access token in a remote tenant.

This is the Entra "Workload Identity Federation using a Managed Identity as issuer" flow:
https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity

## Motivation

Cross-tenant access from Grafana Azure data sources currently requires a client secret or certificate stored in the data source config, with the associated rotation burden. FIC removes the secret entirely: the local MI's token is the credential, and Entra federates trust to a target App Registration via a one-time FIC config.

This is the first step in addressing my user request in grafana/azure-prometheus-datasource#199. I'd like to publish a follow-up PR against the `azure-prometheus-datasource` plugin will wire this credential type into the data source UI and config once this PR is merged and a new SDK version is tagged.

## Validation

- End-to-end tested with a system-assigned MI on a VM in tenant A, a multi-tenant App Reg in tenant A provisioned into tenant B, and an Azure Monitor Workspace in tenant B. The Azure Managed Prometheus data source (separate PR) successfully queries the AMW.
- New retriever and builder tests added.
- All existing tests pass.

## Notes

- Workload Identity as a source was considered but dropped. AKS deployments with WI can already federate directly to a cross-tenant App Registration through the existing `workloadidentity` auth type, so the two-step bridge would be redundant.