### PR TITLE
azhttpclient: don't fail requests when no user is in context for rate-limit session

### DIFF
--- a/azhttpclient/middleware.go
+++ b/azhttpclient/middleware.go
@@ -70,9 +70,14 @@ func applyAzureAuth(tokenProvider aztokenprovider.AzureTokenProvider, sessionPro
 
 		if sessionProvider != nil {
 			sessionId, err := sessionProvider.GetSessionId(reqContext)
-			if err != nil {
+			switch {
+			case errors.Is(err, ErrUserContextNotConfigured):
+				// No user in context (e.g. service-context calls such as multi-tenant
+				// health checks). The rate-limit session id is optional metadata, so
+				// omit the header instead of failing the request.
+			case err != nil:
 				return nil, fmt.Errorf("failed to obtain user session: %w", err)
-			} else if sessionId != "" {
+			case sessionId != "":
 				req.Header.Set("x-ms-ratelimit-id", sessionId)
 			}
 		}

--- a/azhttpclient/middleware_test.go
+++ b/azhttpclient/middleware_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/v2/aztokenprovider"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,6 +138,49 @@ func TestAzureMiddleware(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+
+	t.Run("given rate-limit session enabled", func(t *testing.T) {
+		newMiddleware := func(capture *testRoundTripper) http.RoundTripper {
+			authOpts := NewAuthOptions(azureSettings)
+			authOpts.Scopes([]string{"https://datasource.example.org/.default"})
+			authOpts.AddRateLimitSession(true)
+			authOpts.AddTokenProvider(azureAuthCustom, func(_ *azsettings.AzureSettings, _ azcredentials.AzureCredentials) (aztokenprovider.AzureTokenProvider, error) {
+				return &customTokenProvider{}, nil
+			})
+			return AzureMiddleware(authOpts, &customCredentials{}).CreateMiddleware(clientOpts, capture)
+		}
+
+		t.Run("should set the rate-limit header when a user is in context", func(t *testing.T) {
+			capture := &testRoundTripper{}
+			middleware := newMiddleware(capture)
+
+			req, err := http.NewRequest("GET", "https://testendpoint.microsoft.com", nil)
+			require.NoError(t, err)
+			usrctx := azusercontext.WithCurrentUser(req.Context(), azusercontext.CurrentUserContext{
+				User: &backend.User{Login: "user1@example.org"},
+			})
+
+			resp, err := middleware.RoundTrip(req.WithContext(usrctx))
+			require.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode)
+			assert.NotEmpty(t, capture.lastReq.Header.Get("x-ms-ratelimit-id"))
+		})
+
+		t.Run("should succeed without the rate-limit header when no user is in context", func(t *testing.T) {
+			capture := &testRoundTripper{}
+			middleware := newMiddleware(capture)
+
+			// Simulates service-context calls such as multi-tenant health checks where
+			// there is no acting Grafana user. The request must not fail.
+			req, err := http.NewRequest("GET", "https://testendpoint.microsoft.com", nil)
+			require.NoError(t, err)
+
+			resp, err := middleware.RoundTrip(req)
+			require.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode)
+			assert.Empty(t, capture.lastReq.Header.Get("x-ms-ratelimit-id"))
+		})
+	})
 }
 
 const (
@@ -169,8 +214,10 @@ func (provider *customTokenProvider) GetAccessToken(ctx context.Context, scopes 
 }
 
 type testRoundTripper struct {
+	lastReq *http.Request
 }
 
-func (rt *testRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.lastReq = req
 	return &http.Response{Status: "200 OK", StatusCode: 200}, nil
 }

--- a/azhttpclient/session_provider.go
+++ b/azhttpclient/session_provider.go
@@ -18,6 +18,11 @@ var (
 	processSeedOk bool
 )
 
+// ErrUserContextNotConfigured is returned by GetSessionId when there is no Grafana
+// user in the request context (e.g. service-context calls such as multi-tenant health
+// checks). Callers should treat the rate-limit session id as optional in that case.
+var ErrUserContextNotConfigured = errors.New("user context not configured")
+
 type userSessionProvider struct {
 	seed []byte
 }
@@ -57,7 +62,7 @@ func (p *userSessionProvider) GetSessionId(ctx context.Context) (string, error) 
 
 	currentUser, ok := azusercontext.GetCurrentUser(ctx)
 	if !ok || currentUser.User == nil {
-		return "", fmt.Errorf("user context not configured")
+		return "", ErrUserContextNotConfigured
 	}
 
 	hash := sha256.New()

--- a/azhttpclient/session_provider_test.go
+++ b/azhttpclient/session_provider_test.go
@@ -28,7 +28,7 @@ func TestSessionProvider(t *testing.T) {
 		sessionProvider, err := newSessionProvider()
 		require.NoError(t, err)
 		sessionId, err := sessionProvider.GetSessionId(context.Background())
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUserContextNotConfigured)
 		require.Empty(t, sessionId)
 	})
 
@@ -39,7 +39,7 @@ func TestSessionProvider(t *testing.T) {
 			IdToken: "FAKE_ID_TOKEN",
 		})
 		sessionId, err := sessionProvider.GetSessionId(usrctx)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUserContextNotConfigured)
 		require.Empty(t, sessionId)
 	})
 }


### PR DESCRIPTION
## Summary

When running Azure Monitor as a MT server, the health check for a datasource using `AddRateLimitSession` fails because there is no user context (not triggered by a user).

## What

When rate-limit sessions are enabled (`AddRateLimitSession(true)`, used by the Azure Monitor datasource), the middleware computes an optional `x-ms-ratelimit-id` header via the user session provider. That provider requires a Grafana user in the request context.

Any request **without** a user — e.g. a **multi-tenant health check** that runs under a service identity — failed hard with:

```
failed to obtain user session: user context not configured
```

even though the Azure access token itself was obtained successfully. The same datasource's health check succeeds in single-tenant Grafana (a real user is in context) but fails in the MT path.

## Change

- Treat a missing user context as a **non-fatal, expected** state: skip the optional `x-ms-ratelimit-id` header instead of failing the whole request.
- Introduce an exported sentinel `ErrUserContextNotConfigured` from the session provider so the middleware can distinguish "no user in context" from a genuine session-provider error (which still fails as before).

The `x-ms-ratelimit-id` header is purely an optimization to let Azure distinguish different Grafana users sharing one identity for server-side rate limiting; its absence should never fail a request.

Note: the identically-worded error in `aztokenprovider` (the current-user/on-behalf-of **token** path) is intentionally left unchanged — failing there is correct when the datasource is configured for user auth.

## Tests

- `session_provider_test.go`: the no-user cases now assert `errors.Is(err, ErrUserContextNotConfigured)`.
- `middleware_test.go`: new `given rate-limit session enabled` block — header is set when a user is present, and the request succeeds **without** the header when no user is in context (the MT health-check scenario).

`go test ./...` and `go vet ./...` pass.

## Verification

Verified end-to-end: an Azure Monitor (client-secret / App Registration) datasource whose MT health check returned HTTP 400 `user context not configured` now returns `status: OK` with this fix wired into Grafana via `go work`.